### PR TITLE
Migrate to .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up .NET 9
+      - name: Set up .NET 10
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore SharedSpaces.sln

--- a/.squad/log/2026-03-17T09-58-pr-feedback.md
+++ b/.squad/log/2026-03-17T09-58-pr-feedback.md
@@ -1,0 +1,28 @@
+# Session: PR #33 Feedback (2026-03-17)
+
+**Date:** 2026-03-17 09:58  
+**Topic:** PR #33 review feedback follow-up  
+**Agents:** Kaylee (Backend Dev), Zoe (Tester)
+
+## Work Done
+
+**Kaylee** addressed 4 items in production code:
+- Bearer challenge for middleware rejections (standard 401 response shape)
+- Query optimization with `.AsNoTracking()`
+- Concurrency handling for invitation re-use races
+- history.md update (commit f3c5bee)
+
+**Zoe** addressed 3 items in test code:
+- Reuse production `InvitationPinHasher` via `InternalsVisibleTo`
+- Add `PrivateAssets` to test package dependencies
+- history.md update (commit 328437e)
+
+**Tests Passing:** 13/13 in both agents
+
+## Decisions Merged
+✅ Kaylee PR Feedback → decisions.md  
+✅ Zoe PR Feedback → decisions.md
+
+## Next Steps
+- PR #33 review feedback fully addressed
+- Code ready for merge to `main`

--- a/.squad/orchestration-log/2026-03-17T09-58-kaylee-pr-feedback.md
+++ b/.squad/orchestration-log/2026-03-17T09-58-kaylee-pr-feedback.md
@@ -1,0 +1,23 @@
+# Kaylee: PR #33 Feedback (2026-03-17 09:58)
+
+## Task
+Address Copilot PR review feedback on production code in `src/SharedSpaces.Server/Features/Tokens/`.
+
+## Feedback Items
+1. **Bearer challenge:** `SpaceMemberAuthorizationMiddleware` short-circuiting with bare 401 instead of JWT bearer challenge
+2. **Query optimization:** Token exchange query could use `.AsNoTracking()`
+3. **Concurrency handling:** Token exchange not handling invitation re-use races
+4. **history.md fix:** Add learning about bearer challenge standard 401 response shape
+
+## Outcome
+✅ All 4 items addressed
+
+**Files Modified:**
+- `src/SharedSpaces.Server/Features/Tokens/JwtAuthenticationExtensions.cs`
+- `src/SharedSpaces.Server/Features/Tokens/TokenEndpoints.cs`
+- `.squad/agents/kaylee/history.md`
+
+**Commits:**
+- f3c5bee: fix: address PR review feedback on auth middleware, query optimization, and concurrency
+
+**Tests:** 13/13 passing

--- a/.squad/orchestration-log/2026-03-17T09-58-zoe-pr-feedback.md
+++ b/.squad/orchestration-log/2026-03-17T09-58-zoe-pr-feedback.md
@@ -1,0 +1,23 @@
+# Zoe: PR #33 Feedback (2026-03-17 09:58)
+
+## Task
+Address Copilot PR review feedback on test code in `tests/SharedSpaces.Server.Tests/`.
+
+## Feedback Items
+1. **Reuse production PIN hasher:** Via `InternalsVisibleTo` instead of duplicating hash logic in tests
+2. **PrivateAssets on test packages:** Prevent test dependencies from leaking to consumers
+3. **history.md fix:** Add learning about `InternalsVisibleTo` for security-sensitive helpers
+
+## Outcome
+✅ All 3 items addressed
+
+**Files Modified:**
+- `tests/SharedSpaces.Server.Tests/TokenEndpointTests.cs`
+- `tests/SharedSpaces.Server.Tests/SharedSpaces.Server.Tests.csproj`
+- `src/SharedSpaces.Server/SharedSpaces.Server.csproj`
+- `.squad/agents/zoe/history.md`
+
+**Commits:**
+- 328437e: test: address PR review feedback on test project
+
+**Tests:** 13/13 passing

--- a/src/SharedSpaces.Server/SharedSpaces.Server.csproj
+++ b/src/SharedSpaces.Server/SharedSpaces.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -13,12 +13,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
     <PackageReference Include="QRCoder" Version="1.7.0" />
   </ItemGroup>
 

--- a/tests/SharedSpaces.Server.Tests/SharedSpaces.Server.Tests.csproj
+++ b/tests/SharedSpaces.Server.Tests/SharedSpaces.Server.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" PrivateAssets="all" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />


### PR DESCRIPTION
Closes #34

- Update TargetFramework to net10.0 in all projects
- Update Microsoft.* NuGet packages to 10.0.x
- Add Microsoft.IdentityModel.JsonWebTokens (required for .NET 10 JWT validation)
- Update CI workflow to use .NET 10 SDK

All tests pass successfully with the new .NET 10 SDK.