### PR TITLE
Add single-file Aspire AppHost for dev orchestration

### DIFF
--- a/src/AppHost.cs
+++ b/src/AppHost.cs
@@ -1,0 +1,20 @@
+#:sdk Aspire.AppHost.Sdk@13.0.2
+#:project .\SharedSpaces.Server\SharedSpaces.Server.csproj
+#:package Aspire.Hosting.NodeJs@9.5.2
+
+var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+{
+    DashboardApplicationName = "SharedSpaces",
+    Args = args,
+});
+
+var server = builder.AddProject<Projects.SharedSpaces_Server>("server");
+
+var client = builder.AddNpmApp("client", "./SharedSpaces.Client", "dev")
+    .WithHttpEndpoint(port: 5173, env: "PORT")
+    .WithEnvironment("BROWSER", "none")
+    .WaitFor(server);
+
+server.WithEnvironment("Server__DefaultClientAppUrl", client.GetEndpoint("http"));
+
+builder.Build().Run();

--- a/src/AppHost.run.json
+++ b/src/AppHost.run.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15200",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19100",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20100",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS": "true"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17300;http://localhost:15200",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21300",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22300"
+      }
+    }
+  }
+}

--- a/src/SharedSpaces.Client/vite.config.ts
+++ b/src/SharedSpaces.Client/vite.config.ts
@@ -4,11 +4,11 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   plugins: [tailwindcss()],
   server: {
-    host: '127.0.0.1',
-    port: 5173,
+    host: 'localhost',
+    port: parseInt(process.env.PORT || '5173'),
   },
   preview: {
-    host: '127.0.0.1',
+    host: 'localhost',
     port: 4173,
   },
 });


### PR DESCRIPTION
## What
Add a single-file Aspire AppHost that orchestrates both the .NET server and Vite client for seamless local development.

## Why
Simplifies the development loop by allowing everything to run with a single command, with the Aspire dashboard providing visibility into both services and automatic port/endpoint management.

## How to Use
`ash
dotnet run src/AppHost.cs
`

This will start the Aspire dashboard (http://localhost:18889) where you can see both services running and access them through the proxy.

## Changes
- **src/AppHost.cs** (NEW): Single-file Aspire AppHost using #:sdk, #:project, #:package directives. No .csproj needed. Configures:
  - .NET server as an executable resource
  - npm/Vite client as an npm resource
  - Proper port bindings and environment variables

- **src/AppHost.run.json** (NEW): Launch profiles with required environment variables:
  - http profile on port 15200
  - https profile on port 17300

- **src/SharedSpaces.Client/vite.config.ts** (MODIFIED):
  - Changed server.host from 127.0.0.1 to localhost for Aspire dashboard compatibility
  - Made server.port read from PORT environment variable with fallback to 5173 for Aspire proxy integration
