### PR TITLE
Fix heartbeat racing triage on non-squad label events

### DIFF
--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -22,12 +22,13 @@ permissions:
 
 jobs:
   heartbeat:
-    # Skip when the base "squad" label is added — squad-triage.yml handles that.
-    # This prevents Ralph from racing the triage workflow and double-assigning.
+    # Only run on labeled events for squad:{member} labels (assignment changes).
+    # Skip ALL other labels (squad, type:*, go:*, priority:*, etc.) to prevent
+    # racing squad-triage.yml which handles the initial "squad" label routing.
     if: >-
       github.event_name != 'issues'
       || github.event.action != 'labeled'
-      || github.event.label.name != 'squad'
+      || startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Double triage comments on issue #67 — same race condition pattern as #58, despite the fix in #63.

**Root cause:** PR #63 only blocked the heartbeat when the exact `squad` label was added. But when an issue gets multiple labels simultaneously (e.g. `squad` + `type:bug`), each label generates a separate `labeled` event. The `type:bug` event passed the heartbeat's filter (`!= 'squad'`), ran concurrently with `squad-triage.yml`, queried the API before triage added `squad:mal`, and posted a duplicate triage comment.

**Evidence from workflow runs:**
- Heartbeat run #76 (`squad` label): **skipped** ✓ (PR #63's fix worked)
- Heartbeat run #77 (`type:bug` label): **success** ⚠️ (raced triage)
- Triage run #27 (`squad` label): **success** ✓

## Fix

Change the heartbeat `if` condition from `github.event.label.name != 'squad'` to `startsWith(github.event.label.name, 'squad:')`.

Now only `squad:{member}` labels (assignment changes) trigger the heartbeat. All other labels — `squad`, `type:*`, `go:*`, `priority:*` — are skipped.

| Event | Before | After |
|-------|--------|-------|
| `labeled: squad` | skip ✓ | skip ✓ |
| `labeled: type:bug` | **run** ⚠️ | skip ✓ |
| `labeled: go:needs-research` | **run** ⚠️ | skip ✓ |
| `labeled: squad:mal` | run ✓ | run ✓ |
| `issues.closed` | run ✓ | run ✓ |
| `workflow_dispatch` | run ✓ | run ✓ |

Closes #67