### PR TITLE
fix(client): Card action button padding and pending upload borders

### DIFF
--- a/src/SharedSpaces.Client/src/features/space-view/space-view.test.ts
+++ b/src/SharedSpaces.Client/src/features/space-view/space-view.test.ts
@@ -2336,11 +2336,12 @@ describe('SpaceView - Unified Item Card Layout', () => {
       const card = Array.from(cards || []).find(c => 
         c.classList.contains('rounded-lg') && 
         c.classList.contains('border') && 
-        c.classList.contains('border-slate-800')
+        c.classList.contains('border-amber-500/40')
       );
       expect(card).toBeTruthy();
       expect(card?.classList.contains('px-4')).toBe(true);
       expect(card?.classList.contains('py-3')).toBe(true);
+      expect(card?.classList.contains('bg-amber-950/20')).toBe(true);
 
       // Verify content is rendered
       expect(section?.textContent).toContain('Shared text from another app');
@@ -2365,16 +2366,17 @@ describe('SpaceView - Unified Item Card Layout', () => {
       );
       expect(section).toBeTruthy();
 
-      // Verify the unified card layout is used
+      // Verify the unified card layout is used with amber variant
       const cards = section?.querySelectorAll('li');
       const card = Array.from(cards || []).find(c => 
         c.classList.contains('rounded-lg') && 
         c.classList.contains('border') && 
-        c.classList.contains('border-slate-800')
+        c.classList.contains('border-amber-500/40')
       );
       expect(card).toBeTruthy();
       expect(card?.classList.contains('px-4')).toBe(true);
       expect(card?.classList.contains('py-3')).toBe(true);
+      expect(card?.classList.contains('bg-amber-950/20')).toBe(true);
 
       // Verify file name is rendered
       expect(section?.textContent).toContain('shared-doc.pdf');
@@ -2441,7 +2443,7 @@ describe('SpaceView - Unified Item Card Layout', () => {
       const cards = Array.from(allLis || []).filter(c => 
         c.classList.contains('rounded-lg') && 
         c.classList.contains('border') && 
-        c.classList.contains('border-slate-800')
+        c.classList.contains('border-amber-500/40')
       );
       
       // Should have 2 cards
@@ -2456,7 +2458,7 @@ describe('SpaceView - Unified Item Card Layout', () => {
       });
     });
 
-    it('pending share cards and regular item cards have the same wrapper classes', async () => {
+    it('pending share cards and regular item cards share the same base layout classes', async () => {
       // Set up both regular items and pending shares
       const item = makeItem({ content: 'Regular item' });
       (element as any).items = [item];
@@ -2471,18 +2473,26 @@ describe('SpaceView - Unified Item Card Layout', () => {
       (element as any).requestUpdate();
       await element.updateComplete;
 
-      // Get all cards
+      // Get regular item cards (border-slate-800)
       const allLis = element.querySelectorAll('li');
-      const allCards = Array.from(allLis).filter(c => 
+      const regularCards = Array.from(allLis).filter(c => 
         c.classList.contains('rounded-lg') && 
         c.classList.contains('border') && 
         c.classList.contains('border-slate-800')
       );
-      expect(allCards.length).toBeGreaterThanOrEqual(2);
+      expect(regularCards.length).toBeGreaterThanOrEqual(1);
 
-      // Verify all cards have the same base classes
+      // Get pending share cards (border-amber-500/40)
+      const pendingCards = Array.from(allLis).filter(c => 
+        c.classList.contains('rounded-lg') && 
+        c.classList.contains('border') && 
+        c.classList.contains('border-amber-500/40')
+      );
+      expect(pendingCards.length).toBeGreaterThanOrEqual(1);
+
+      // Verify all cards share the same base layout classes
       const expectedClasses = ['relative', 'overflow-hidden', 'rounded-lg', 'border', 'px-4', 'py-3'];
-      allCards.forEach(card => {
+      [...regularCards, ...pendingCards].forEach(card => {
         expectedClasses.forEach(cls => {
           expect(card.classList.contains(cls)).toBe(true);
         });

--- a/src/SharedSpaces.Client/src/features/space-view/space-view.ts
+++ b/src/SharedSpaces.Client/src/features/space-view/space-view.ts
@@ -837,7 +837,7 @@ export class SpaceView extends BaseElement {
 
     return html`
       <section
-        class="rounded-lg border border-amber-500/30 bg-amber-950/20 p-4 space-y-3"
+        class="space-y-3"
       >
         <div class="flex items-center justify-between gap-3">
           <p class="text-sm font-medium text-amber-300">
@@ -899,7 +899,7 @@ export class SpaceView extends BaseElement {
               </div>
             `;
 
-            return this.renderUnifiedItemCard(content);
+            return this.renderUnifiedItemCard(content, undefined, 'border-amber-500/40', 'bg-amber-950/20');
           })}
         </ul>
       </section>
@@ -1039,10 +1039,12 @@ export class SpaceView extends BaseElement {
   private renderUnifiedItemCard(
     content: TemplateResult | typeof nothing,
     overlay?: TemplateResult | typeof nothing,
+    borderClass = 'border-slate-800',
+    bgClass = 'bg-slate-900/60',
   ) {
     return html`
       <li
-        class="relative overflow-hidden rounded-lg border border-slate-800 bg-slate-900/60 px-4 py-3"
+        class="relative overflow-hidden rounded-lg border ${borderClass} ${bgClass} px-4 py-3"
       >
         <div class="flex items-center gap-3">
           ${content}


### PR DESCRIPTION
## Changes

### Card action button padding
Adds \-mr-2\ to action button wrappers (text items, file items, pending shares) to compensate for the buttons' \p-2\ padding. This visually aligns the right edge of the card icons with the left content, while preserving the full click target area.

### Pending upload borders
- Removed the amber border from the wrapping \<section>\ container
- Added \order-amber-500/40\ to each individual pending upload card
- Added an optional \orderClass\ parameter to \enderUnifiedItemCard\ (defaults to \order-slate-800\)