### PR TITLE
ci(client): add Azure SWA preview deploy workflow

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -11,8 +11,13 @@ permissions:
 jobs:
   deploy:
     name: Deploy Preview
-    if: contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'deploy-preview') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    concurrency:
+      group: preview-deploy-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
 
@@ -20,6 +25,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: src/SharedSpaces.Client/package-lock.json
 
       - name: Install dependencies
         working-directory: src/SharedSpaces.Client
@@ -38,17 +45,24 @@ jobs:
           action: upload
           skip_app_build: true
           app_location: src/SharedSpaces.Client/dist
+          output_location: ''
 
   teardown:
     name: Teardown Preview
     if: >-
       github.event_name == 'pull_request' &&
       github.event.action == 'unlabeled' &&
-      github.event.label.name == 'deploy-preview'
+      github.event.label.name == 'deploy-preview' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    concurrency:
+      group: preview-deploy-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - name: Close staging environment
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_PREVIEW_API_TOKEN }}
           action: close
+          skip_app_build: true
+          app_location: src/SharedSpaces.Client/dist


### PR DESCRIPTION
## Summary

Label-triggered PR preview deployment to Azure Static Web Apps.

### How it works

1. Add the `deploy-preview` label to a PR → builds & deploys to SWA staging
2. Push new commits → auto-redeploys (label stays, `synchronize` event fires)
3. Remove the label → tears down the staging environment

### Security

- Only collaborators with **write access** can add labels, so external contributors can't trigger deployments
- Uses `AZURE_STATIC_WEB_APPS_PREVIEW_API_TOKEN` repo secret (needs to be configured)

### Setup required

1. Create an Azure Static Web Apps resource
2. Add the deployment token as `AZURE_STATIC_WEB_APPS_PREVIEW_API_TOKEN` in repo secrets
3. Create a `deploy-preview` label in the repo