### PR TITLE
fix(client,server): remove spaceId from token exchange

### DIFF
--- a/src/SharedSpaces.Client/src/features/join/join-view.test.ts
+++ b/src/SharedSpaces.Client/src/features/join/join-view.test.ts
@@ -1,0 +1,429 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock dependencies before importing the component
+const mockExchangeToken = vi.fn();
+vi.mock('../../lib/api-client', () => ({
+  exchangeToken: (...args: unknown[]) => mockExchangeToken(...args),
+  TokenExchangeError: class TokenExchangeError extends Error {
+    statusCode?: number;
+    constructor(message: string, statusCode?: number) {
+      super(message);
+      this.name = 'TokenExchangeError';
+      this.statusCode = statusCode;
+    }
+  },
+}));
+
+const mockParseInvitationString = vi.fn();
+const mockParseInvitationFromUrl = vi.fn();
+vi.mock('../../lib/invitation', () => ({
+  parseInvitationString: (...args: unknown[]) => mockParseInvitationString(...args),
+  parseInvitationFromUrl: (...args: unknown[]) => mockParseInvitationFromUrl(...args),
+}));
+
+const mockGetPrimaryDisplayName = vi.fn().mockReturnValue('');
+const mockSetPrimaryDisplayName = vi.fn();
+const mockSetToken = vi.fn();
+vi.mock('../../lib/token-storage', () => ({
+  getPrimaryDisplayName: () => mockGetPrimaryDisplayName(),
+  setPrimaryDisplayName: (...args: unknown[]) => mockSetPrimaryDisplayName(...args),
+  setToken: (...args: unknown[]) => mockSetToken(...args),
+}));
+
+vi.mock('jwt-decode', () => ({
+  jwtDecode: () => ({
+    sub: 'member-1',
+    display_name: 'Alice',
+    server_url: 'http://localhost:5000',
+    space_id: 'space-1',
+    space_name: 'Test Space',
+  }),
+}));
+
+import './join-view';
+import { JoinView } from './join-view';
+
+describe('join-view', () => {
+  let element: JoinView;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockParseInvitationFromUrl.mockReturnValue(null);
+    mockGetPrimaryDisplayName.mockReturnValue('');
+
+    element = document.createElement('join-view') as JoinView;
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  describe('initialization', () => {
+    it('starts in paste entry mode', async () => {
+      await element.updateComplete;
+      expect((element as any).entryMode).toBe('paste');
+    });
+
+    it('pre-fills display name from localStorage', async () => {
+      element.remove();
+      mockGetPrimaryDisplayName.mockReturnValue('Saved Name');
+
+      element = document.createElement('join-view') as JoinView;
+      document.body.appendChild(element);
+      await element.updateComplete;
+
+      expect((element as any).displayName).toBe('Saved Name');
+    });
+
+    it('parses invitation from URL on connect', async () => {
+      element.remove();
+      mockParseInvitationFromUrl.mockReturnValue({
+        serverUrl: 'http://example.com',
+        pin: '123456',
+      });
+
+      element = document.createElement('join-view') as JoinView;
+      document.body.appendChild(element);
+      await element.updateComplete;
+
+      expect((element as any).serverUrl).toBe('http://example.com');
+      expect((element as any).pin).toBe('123456');
+      expect((element as any).invitationString).toBe('http://example.com|123456');
+    });
+
+    it('builds 3-part invitation string for legacy URL invitations', async () => {
+      element.remove();
+      mockParseInvitationFromUrl.mockReturnValue({
+        serverUrl: 'http://example.com',
+        spaceId: '550e8400-e29b-41d4-a716-446655440000',
+        pin: '123456',
+      });
+
+      element = document.createElement('join-view') as JoinView;
+      document.body.appendChild(element);
+      await element.updateComplete;
+
+      expect((element as any).invitationString).toBe(
+        'http://example.com|550e8400-e29b-41d4-a716-446655440000|123456'
+      );
+    });
+  });
+
+  describe('invitation paste mode', () => {
+    it('auto-parses a valid invitation string', async () => {
+      await element.updateComplete;
+
+      mockParseInvitationString.mockReturnValue({
+        serverUrl: 'http://example.com',
+        pin: '654321',
+      });
+
+      (element as any).handleInvitationPaste({
+        target: { value: 'http://example.com|654321' },
+      });
+      await element.updateComplete;
+
+      expect((element as any).serverUrl).toBe('http://example.com');
+      expect((element as any).pin).toBe('654321');
+    });
+
+    it('clears fields when invitation string is invalid', async () => {
+      await element.updateComplete;
+
+      // First set valid state
+      (element as any).serverUrl = 'http://example.com';
+      (element as any).pin = '123456';
+
+      mockParseInvitationString.mockReturnValue(null);
+      (element as any).handleInvitationPaste({
+        target: { value: 'garbage' },
+      });
+      await element.updateComplete;
+
+      expect((element as any).serverUrl).toBe('');
+      expect((element as any).pin).toBe('');
+    });
+
+    it('clears error message on input', async () => {
+      await element.updateComplete;
+      (element as any).errorMessage = 'Previous error';
+
+      mockParseInvitationString.mockReturnValue(null);
+      (element as any).handleInvitationPaste({
+        target: { value: 'test' },
+      });
+
+      expect((element as any).errorMessage).toBe('');
+    });
+  });
+
+  describe('manual entry mode', () => {
+    it('toggles between paste and manual modes', async () => {
+      await element.updateComplete;
+
+      expect((element as any).entryMode).toBe('paste');
+      (element as any).toggleEntryMode();
+      expect((element as any).entryMode).toBe('manual');
+      (element as any).toggleEntryMode();
+      expect((element as any).entryMode).toBe('paste');
+    });
+
+    it('updates serverUrl on input', async () => {
+      await element.updateComplete;
+
+      (element as any).handleServerUrlInput({
+        target: { value: 'http://new-server.com' },
+      });
+
+      expect((element as any).serverUrl).toBe('http://new-server.com');
+    });
+
+    it('updates pin on input', async () => {
+      await element.updateComplete;
+
+      (element as any).handlePinInput({
+        target: { value: '999999' },
+      });
+
+      expect((element as any).pin).toBe('999999');
+    });
+
+    it('has no spaceId state property', async () => {
+      await element.updateComplete;
+
+      // spaceId was removed — the manual form only has serverUrl and pin
+      expect((element as any).spaceId).toBeUndefined();
+    });
+  });
+
+  describe('display name', () => {
+    it('updates displayName on input', async () => {
+      await element.updateComplete;
+
+      (element as any).handleDisplayNameInput({
+        target: { value: 'Bob' },
+      });
+
+      expect((element as any).displayName).toBe('Bob');
+    });
+  });
+
+  describe('validation', () => {
+    it('requires server URL', async () => {
+      await element.updateComplete;
+
+      (element as any).serverUrl = '';
+      (element as any).pin = '123456';
+      (element as any).displayName = 'Alice';
+
+      await (element as any).handleJoin();
+
+      expect((element as any).errorMessage).toBe('Please provide server URL and PIN.');
+      expect(mockExchangeToken).not.toHaveBeenCalled();
+    });
+
+    it('requires PIN', async () => {
+      await element.updateComplete;
+
+      (element as any).serverUrl = 'http://example.com';
+      (element as any).pin = '';
+      (element as any).displayName = 'Alice';
+
+      await (element as any).handleJoin();
+
+      expect((element as any).errorMessage).toBe('Please provide server URL and PIN.');
+      expect(mockExchangeToken).not.toHaveBeenCalled();
+    });
+
+    it('requires display name', async () => {
+      await element.updateComplete;
+
+      (element as any).serverUrl = 'http://example.com';
+      (element as any).pin = '123456';
+      (element as any).displayName = '   ';
+
+      await (element as any).handleJoin();
+
+      expect((element as any).errorMessage).toBe('Please enter a display name.');
+      expect(mockExchangeToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleJoin', () => {
+    it('calls exchangeToken with serverUrl, pin, and displayName (no spaceId)', async () => {
+      await element.updateComplete;
+
+      mockExchangeToken.mockResolvedValue({ token: 'jwt-token' });
+
+      (element as any).serverUrl = 'http://example.com';
+      (element as any).pin = '123456';
+      (element as any).displayName = 'Alice';
+
+      await (element as any).handleJoin();
+
+      expect(mockExchangeToken).toHaveBeenCalledWith(
+        'http://example.com',
+        '123456',
+        'Alice'
+      );
+    });
+
+    it('stores token and display name on success', async () => {
+      await element.updateComplete;
+
+      mockExchangeToken.mockResolvedValue({ token: 'jwt-token' });
+
+      (element as any).serverUrl = 'http://example.com';
+      (element as any).pin = '123456';
+      (element as any).displayName = 'Alice';
+
+      await (element as any).handleJoin();
+
+      expect(mockSetToken).toHaveBeenCalledWith(
+        'http://localhost:5000',
+        'space-1',
+        'jwt-token'
+      );
+      expect(mockSetPrimaryDisplayName).toHaveBeenCalledWith('Alice');
+    });
+
+    it('dispatches view-change event on success', async () => {
+      await element.updateComplete;
+
+      mockExchangeToken.mockResolvedValue({ token: 'jwt-token' });
+
+      (element as any).serverUrl = 'http://example.com';
+      (element as any).pin = '123456';
+      (element as any).displayName = 'Alice';
+
+      const eventPromise = new Promise<CustomEvent>((resolve) => {
+        element.addEventListener('view-change', (e) => resolve(e as CustomEvent));
+      });
+
+      await (element as any).handleJoin();
+      const event = await eventPromise;
+
+      expect(event.detail).toEqual({
+        view: 'space',
+        spaceId: 'space-1',
+        serverUrl: 'http://localhost:5000',
+        token: 'jwt-token',
+        displayName: 'Alice',
+        spaceName: 'Test Space',
+      });
+    });
+
+    it('shows error message on TokenExchangeError', async () => {
+      await element.updateComplete;
+
+      const { TokenExchangeError } = await import('../../lib/api-client');
+      mockExchangeToken.mockRejectedValue(new TokenExchangeError('Invalid PIN'));
+
+      (element as any).serverUrl = 'http://example.com';
+      (element as any).pin = '000000';
+      (element as any).displayName = 'Alice';
+
+      await (element as any).handleJoin();
+
+      expect((element as any).errorMessage).toBe('Invalid PIN');
+    });
+
+    it('shows generic error on unexpected failure', async () => {
+      await element.updateComplete;
+
+      mockExchangeToken.mockRejectedValue(new Error('kaboom'));
+
+      (element as any).serverUrl = 'http://example.com';
+      (element as any).pin = '123456';
+      (element as any).displayName = 'Alice';
+
+      await (element as any).handleJoin();
+
+      expect((element as any).errorMessage).toBe(
+        'An unexpected error occurred. Please try again.'
+      );
+    });
+
+    it('sets isLoading during request', async () => {
+      await element.updateComplete;
+
+      let resolveToken: (value: { token: string }) => void;
+      mockExchangeToken.mockReturnValue(
+        new Promise((resolve) => { resolveToken = resolve; })
+      );
+
+      (element as any).serverUrl = 'http://example.com';
+      (element as any).pin = '123456';
+      (element as any).displayName = 'Alice';
+
+      const joinPromise = (element as any).handleJoin();
+      expect((element as any).isLoading).toBe(true);
+
+      resolveToken!({ token: 'jwt-token' });
+      await joinPromise;
+      expect((element as any).isLoading).toBe(false);
+    });
+
+    it('resets isLoading on failure', async () => {
+      await element.updateComplete;
+
+      mockExchangeToken.mockRejectedValue(new Error('fail'));
+
+      (element as any).serverUrl = 'http://example.com';
+      (element as any).pin = '123456';
+      (element as any).displayName = 'Alice';
+
+      await (element as any).handleJoin();
+      expect((element as any).isLoading).toBe(false);
+    });
+  });
+
+  describe('render', () => {
+    it('renders invitation input in paste mode', async () => {
+      await element.updateComplete;
+
+      const input = element.querySelector('#invitation') as HTMLInputElement;
+      expect(input).toBeTruthy();
+      expect(input.placeholder).toBe('https://server.com|123456');
+    });
+
+    it('renders serverUrl and pin inputs in manual mode', async () => {
+      (element as any).entryMode = 'manual';
+      await element.updateComplete;
+
+      expect(element.querySelector('#serverUrl')).toBeTruthy();
+      expect(element.querySelector('#pin')).toBeTruthy();
+    });
+
+    it('does not render spaceId input in manual mode', async () => {
+      (element as any).entryMode = 'manual';
+      await element.updateComplete;
+
+      expect(element.querySelector('#spaceId')).toBeNull();
+    });
+
+    it('renders display name input', async () => {
+      await element.updateComplete;
+      expect(element.querySelector('#displayName')).toBeTruthy();
+    });
+
+    it('shows error message when set', async () => {
+      (element as any).errorMessage = 'Something went wrong';
+      await element.updateComplete;
+
+      const errorEl = element.querySelector('.text-red-400');
+      expect(errorEl).toBeTruthy();
+      expect(errorEl!.textContent).toContain('Something went wrong');
+    });
+
+    it('shows loading state on join button', async () => {
+      (element as any).isLoading = true;
+      await element.updateComplete;
+
+      const button = element.querySelector('button[class*="bg-sky-400"]');
+      expect(button).toBeTruthy();
+      expect(button!.textContent).toContain('Joining...');
+    });
+  });
+});

--- a/src/SharedSpaces.Client/src/features/join/join-view.ts
+++ b/src/SharedSpaces.Client/src/features/join/join-view.ts
@@ -30,7 +30,6 @@ export class JoinView extends BaseElement {
 
   @state() private invitationString = '';
   @state() private serverUrl = '';
-  @state() private spaceId: string | undefined = undefined;
   @state() private pin = '';
   @state() private displayName = '';
   @state() private isLoading = false;
@@ -44,7 +43,6 @@ export class JoinView extends BaseElement {
     const urlInvitation = parseInvitationFromUrl();
     if (urlInvitation) {
       this.serverUrl = urlInvitation.serverUrl;
-      this.spaceId = urlInvitation.spaceId;
       this.pin = urlInvitation.pin;
       this.invitationString = urlInvitation.spaceId
         ? `${urlInvitation.serverUrl}|${urlInvitation.spaceId}|${urlInvitation.pin}`
@@ -69,11 +67,9 @@ export class JoinView extends BaseElement {
     const parsed = parseInvitationString(this.invitationString);
     if (parsed) {
       this.serverUrl = parsed.serverUrl;
-      this.spaceId = parsed.spaceId;
       this.pin = parsed.pin;
     } else {
       this.serverUrl = '';
-      this.spaceId = undefined;
       this.pin = '';
     }
   };
@@ -81,12 +77,6 @@ export class JoinView extends BaseElement {
   private handleServerUrlInput = (e: Event) => {
     const input = e.target as HTMLInputElement;
     this.serverUrl = input.value;
-    this.errorMessage = '';
-  };
-
-  private handleSpaceIdInput = (e: Event) => {
-    const input = e.target as HTMLInputElement;
-    this.spaceId = input.value || undefined;
     this.errorMessage = '';
   };
 
@@ -127,7 +117,6 @@ export class JoinView extends BaseElement {
       // Exchange PIN for JWT
       const response = await exchangeToken(
         this.serverUrl,
-        this.spaceId,
         this.pin,
         this.displayName.trim()
       );
@@ -223,16 +212,6 @@ export class JoinView extends BaseElement {
                     @input=${this.handleServerUrlInput}
                     ?disabled=${this.isLoading}
                     class="w-full rounded-lg border border-slate-700 bg-slate-900 px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400/20"
-                  />
-                  <input
-                    id="spaceId"
-                    type="text"
-                    placeholder="Space ID (optional)"
-                    aria-label="Space ID (optional)"
-                    .value=${this.spaceId ?? ''}
-                    @input=${this.handleSpaceIdInput}
-                    ?disabled=${this.isLoading}
-                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-4 py-3 text-sm font-mono text-white placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400/20"
                   />
                   <input
                     id="pin"

--- a/src/SharedSpaces.Client/src/lib/api-client.test.ts
+++ b/src/SharedSpaces.Client/src/lib/api-client.test.ts
@@ -26,7 +26,7 @@ describe('api-client', () => {
       expect(result).toEqual(mockResponse);
     });
 
-    it('calls correct URL with correct method and headers', async () => {
+    it('calls /v1/tokens with correct method and headers', async () => {
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
@@ -36,7 +36,6 @@ describe('api-client', () => {
 
       await exchangeToken(
         'http://localhost:5000',
-        '550e8400-e29b-41d4-a716-446655440000',
         '123456',
         'Alice'
       );
@@ -49,7 +48,6 @@ describe('api-client', () => {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            spaceId: '550e8400-e29b-41d4-a716-446655440000',
             pin: '123456',
             displayName: 'Alice',
           }),
@@ -64,11 +62,11 @@ describe('api-client', () => {
       });
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', '')
+        exchangeToken('http://localhost:5000', '123456', '')
       ).rejects.toThrow(TokenExchangeError);
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', '')
+        exchangeToken('http://localhost:5000', '123456', '')
       ).rejects.toThrow('Invalid request');
     });
 
@@ -79,7 +77,7 @@ describe('api-client', () => {
       });
 
       try {
-        await exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', '');
+        await exchangeToken('http://localhost:5000', '123456', '');
       } catch (error) {
         expect(error).toBeInstanceOf(TokenExchangeError);
         expect((error as TokenExchangeError).statusCode).toBe(400);
@@ -93,11 +91,11 @@ describe('api-client', () => {
       });
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', 'wrong', 'Alice')
+        exchangeToken('http://localhost:5000', 'wrong', 'Alice')
       ).rejects.toThrow(TokenExchangeError);
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', 'wrong', 'Alice')
+        exchangeToken('http://localhost:5000', 'wrong', 'Alice')
       ).rejects.toThrow('Invalid PIN');
     });
 
@@ -108,26 +106,26 @@ describe('api-client', () => {
       });
 
       try {
-        await exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', 'wrong', 'Alice');
+        await exchangeToken('http://localhost:5000', 'wrong', 'Alice');
       } catch (error) {
         expect(error).toBeInstanceOf(TokenExchangeError);
         expect((error as TokenExchangeError).statusCode).toBe(401);
       }
     });
 
-    it('throws TokenExchangeError on 404 response (space not found)', async () => {
+    it('throws TokenExchangeError on 404 response (endpoint not found)', async () => {
       globalThis.fetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 404,
       });
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-999999999999', '123456', 'Alice')
+        exchangeToken('http://localhost:5000', '123456', 'Alice')
       ).rejects.toThrow(TokenExchangeError);
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-999999999999', '123456', 'Alice')
-      ).rejects.toThrow('Space not found');
+        exchangeToken('http://localhost:5000', '123456', 'Alice')
+      ).rejects.toThrow('Token endpoint not found');
     });
 
     it('throws TokenExchangeError with statusCode 404', async () => {
@@ -137,7 +135,7 @@ describe('api-client', () => {
       });
 
       try {
-        await exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-999999999999', '123456', 'Alice');
+        await exchangeToken('http://localhost:5000', '123456', 'Alice');
       } catch (error) {
         expect(error).toBeInstanceOf(TokenExchangeError);
         expect((error as TokenExchangeError).statusCode).toBe(404);
@@ -148,11 +146,11 @@ describe('api-client', () => {
       globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', 'Alice')
+        exchangeToken('http://localhost:5000', '123456', 'Alice')
       ).rejects.toThrow(TokenExchangeError);
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', 'Alice')
+        exchangeToken('http://localhost:5000', '123456', 'Alice')
       ).rejects.toThrow('Network error');
     });
 
@@ -166,11 +164,11 @@ describe('api-client', () => {
       });
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', 'Alice')
+        exchangeToken('http://localhost:5000', '123456', 'Alice')
       ).rejects.toThrow(TokenExchangeError);
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', 'Alice')
+        exchangeToken('http://localhost:5000', '123456', 'Alice')
       ).rejects.toThrow('Invalid response from server');
     });
 
@@ -182,11 +180,11 @@ describe('api-client', () => {
       });
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', 'Alice')
+        exchangeToken('http://localhost:5000', '123456', 'Alice')
       ).rejects.toThrow(TokenExchangeError);
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', 'Alice')
+        exchangeToken('http://localhost:5000', '123456', 'Alice')
       ).rejects.toThrow('Invalid response from server');
     });
 
@@ -198,11 +196,11 @@ describe('api-client', () => {
       });
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', 'Alice')
+        exchangeToken('http://localhost:5000', '123456', 'Alice')
       ).rejects.toThrow(TokenExchangeError);
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', 'Alice')
+        exchangeToken('http://localhost:5000', '123456', 'Alice')
       ).rejects.toThrow('Invalid response from server');
     });
 
@@ -211,7 +209,7 @@ describe('api-client', () => {
       globalThis.fetch = vi.fn().mockRejectedValue(networkError);
 
       try {
-        await exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', 'Alice');
+        await exchangeToken('http://localhost:5000', '123456', 'Alice');
       } catch (error) {
         expect(error).toBeInstanceOf(TokenExchangeError);
         expect((error as TokenExchangeError).originalError).toBe(networkError);
@@ -225,15 +223,16 @@ describe('api-client', () => {
       });
 
       await expect(
-        exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', 'Alice')
+        exchangeToken('http://localhost:5000', '123456', 'Alice')
       ).rejects.toThrow(TokenExchangeError);
 
       try {
-        await exchangeToken('http://localhost:5000', '550e8400-e29b-41d4-a716-446655440000', '123456', 'Alice');
+        await exchangeToken('http://localhost:5000', '123456', 'Alice');
       } catch (error) {
         expect((error as TokenExchangeError).statusCode).toBe(500);
         expect((error as TokenExchangeError).message).toContain('500');
       }
     });
+
   });
 });

--- a/src/SharedSpaces.Client/src/lib/api-client.ts
+++ b/src/SharedSpaces.Client/src/lib/api-client.ts
@@ -23,7 +23,6 @@ export class TokenExchangeError extends Error {
 /**
  * Exchange PIN + display name for a JWT token
  * @param serverUrl - Server URL (e.g., 'http://localhost:5000')
- * @param spaceId - Space GUID (optional; omit for simplified invitations)
  * @param pin - Invitation PIN
  * @param displayName - User's display name
  * @returns JWT token
@@ -31,7 +30,6 @@ export class TokenExchangeError extends Error {
  */
 export async function exchangeToken(
   serverUrl: string,
-  spaceId: string | undefined,
   pin: string,
   displayName: string
 ): Promise<TokenExchangeResponse> {
@@ -46,7 +44,6 @@ export async function exchangeToken(
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        ...(spaceId ? { spaceId } : {}),
         pin,
         displayName,
       }),
@@ -67,9 +64,7 @@ export async function exchangeToken(
     } else if (response.status === 401) {
       errorMessage = 'Invalid PIN. Please check the PIN and try again.';
     } else if (response.status === 404) {
-      errorMessage = 'Space not found. The invitation may be invalid or expired.';
-    } else if (response.status === 409) {
-      errorMessage = 'Multiple spaces match this PIN. Please use the full invitation link that includes the space ID.';
+      errorMessage = 'Token endpoint not found. Please check the server URL or server version.';
     }
 
     throw new TokenExchangeError(errorMessage, response.status);

--- a/src/SharedSpaces.Server/Features/Tokens/Models.cs
+++ b/src/SharedSpaces.Server/Features/Tokens/Models.cs
@@ -1,5 +1,5 @@
 namespace SharedSpaces.Server.Features.Tokens;
 
-public record CreateTokenRequest(string Pin, string DisplayName, Guid? SpaceId = null);
+public record CreateTokenRequest(string Pin, string DisplayName);
 
 public record TokenResponse(string Token);

--- a/src/SharedSpaces.Server/Features/Tokens/TokenEndpoints.cs
+++ b/src/SharedSpaces.Server/Features/Tokens/TokenEndpoints.cs
@@ -42,45 +42,15 @@ public static class TokenEndpoints
         var adminSecret = configuration["Admin:Secret"] ?? throw new InvalidOperationException("Admin:Secret not configured");
         var hashedPin = InvitationPinHasher.HashPin(request.Pin.Trim(), adminSecret);
 
-        Space? space = null;
-        SpaceInvitation? invitation;
-
-        if (request.SpaceId.HasValue)
-        {
-            space = await db.Spaces
-                .AsNoTracking()
-                .SingleOrDefaultAsync(existingSpace => existingSpace.Id == request.SpaceId.Value);
-
-            if (space == null)
-            {
-                return Results.NotFound(new { Error = "Space not found" });
-            }
-
-            invitation = await db.SpaceInvitations
-                .FirstOrDefaultAsync(i => i.SpaceId == request.SpaceId.Value && i.Pin == hashedPin);
-        }
-        else
-        {
-            var matchingInvitations = await db.SpaceInvitations
-                .Where(i => i.Pin == hashedPin)
-                .Take(2)
-                .ToListAsync();
-
-            if (matchingInvitations.Count > 1)
-            {
-                return Results.Conflict(new { Error = "Multiple invitations match this PIN. Please provide the space ID." });
-            }
-
-            invitation = matchingInvitations.SingleOrDefault();
-        }
+        var invitation = await db.SpaceInvitations
+            .FirstOrDefaultAsync(i => i.Pin == hashedPin);
 
         if (invitation == null)
         {
             return Results.Unauthorized();
         }
 
-        // Load space once if not already loaded (when spaceId was not provided in the request)
-        space ??= await db.Spaces
+        var space = await db.Spaces
             .AsNoTracking()
             .SingleOrDefaultAsync(s => s.Id == invitation.SpaceId);
 

--- a/tests/SharedSpaces.Server.Tests/TokenEndpointTests.cs
+++ b/tests/SharedSpaces.Server.Tests/TokenEndpointTests.cs
@@ -29,7 +29,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, pin);
 
-        var response = await ExchangeTokenAsync(client, space.Id, pin, displayName);
+        var response = await ExchangeTokenAsync(client, pin, displayName);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var token = await ReadTokenAsync(response);
@@ -49,7 +49,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, pin);
 
-        var response = await ExchangeTokenAsync(client, space.Id, pin, displayName);
+        var response = await ExchangeTokenAsync(client, pin, displayName);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var token = await ReadTokenAsync(response);
@@ -67,7 +67,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         var invitation = await factory.CreateInvitationAsync(space.Id, pin);
 
-        var response = await ExchangeTokenAsync(client, space.Id, pin, displayName);
+        var response = await ExchangeTokenAsync(client, pin, displayName);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var token = await ReadTokenAsync(response);
@@ -88,7 +88,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, pin);
 
-        var response = await ExchangeTokenAsync(client, space.Id, pin, displayName);
+        var response = await ExchangeTokenAsync(client, pin, displayName);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var token = await ReadTokenAsync(response);
@@ -111,20 +111,9 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, "123456");
 
-        var response = await ExchangeTokenAsync(client, space.Id, "654321", "Zoe");
+        var response = await ExchangeTokenAsync(client, "654321", "Zoe");
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
-    }
-
-    [Fact]
-    public async Task NonExistentSpace_Returns404()
-    {
-        await using var factory = new TestWebApplicationFactory();
-        using var client = factory.CreateClient();
-
-        var response = await ExchangeTokenAsync(client, Guid.NewGuid(), "123456", "Zoe");
-
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [Fact]
@@ -135,7 +124,7 @@ public class TokenEndpointTests
 
         var space = await factory.CreateSpaceAsync();
 
-        var response = await ExchangeTokenAsync(client, space.Id, "123456", "Zoe");
+        var response = await ExchangeTokenAsync(client, "123456", "Zoe");
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -151,7 +140,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, pin);
 
-        var tokenResponse = await ExchangeTokenAsync(client, space.Id, pin, displayName);
+        var tokenResponse = await ExchangeTokenAsync(client, pin, displayName);
         tokenResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var token = await ReadTokenAsync(tokenResponse);
         await AssertJwtClaimsAsync(factory, token, space.Id, displayName);
@@ -183,7 +172,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, pin);
 
-        var tokenResponse = await ExchangeTokenAsync(client, space.Id, pin, displayName);
+        var tokenResponse = await ExchangeTokenAsync(client, pin, displayName);
         tokenResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var token = await ReadTokenAsync(tokenResponse);
         await AssertJwtClaimsAsync(factory, token, space.Id, displayName);
@@ -211,7 +200,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, pin);
 
-        var tokenResponse = await ExchangeTokenAsync(client, space.Id, pin, displayName);
+        var tokenResponse = await ExchangeTokenAsync(client, pin, displayName);
         tokenResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var token = await ReadTokenAsync(tokenResponse);
         await AssertJwtClaimsAsync(factory, token, space.Id, displayName);
@@ -233,7 +222,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, pin);
 
-        var response = await ExchangeTokenAsync(client, space.Id, pin, displayName);
+        var response = await ExchangeTokenAsync(client, pin, displayName);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var token = await ReadTokenAsync(response);
@@ -253,7 +242,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, pin);
 
-        var response = await ExchangeTokenAsync(client, space.Id, pin, new string('x', 101));
+        var response = await ExchangeTokenAsync(client, pin, new string('x', 101));
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
@@ -271,7 +260,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, pin);
 
-        var response = await ExchangeTokenSimplifiedAsync(client, pin, displayName);
+        var response = await ExchangeTokenAsync(client, pin, displayName);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var token = await ReadTokenAsync(response);
@@ -290,7 +279,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync("My Space");
         await factory.CreateInvitationAsync(space.Id, pin);
 
-        var response = await ExchangeTokenSimplifiedAsync(client, pin, displayName);
+        var response = await ExchangeTokenAsync(client, pin, displayName);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var token = await ReadTokenAsync(response);
@@ -308,7 +297,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         var invitation = await factory.CreateInvitationAsync(space.Id, pin);
 
-        var response = await ExchangeTokenSimplifiedAsync(client, pin, "Zoe");
+        var response = await ExchangeTokenAsync(client, pin, "Zoe");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var invitationStillExists = await factory.WithDbContextAsync(db => db.SpaceInvitations.AnyAsync(x => x.Id == invitation.Id));
@@ -326,7 +315,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, pin);
 
-        var response = await ExchangeTokenSimplifiedAsync(client, pin, displayName);
+        var response = await ExchangeTokenAsync(client, pin, displayName);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var member = await factory.WithDbContextAsync(db => db.SpaceMembers.SingleAsync());
@@ -343,7 +332,7 @@ public class TokenEndpointTests
         var space = await factory.CreateSpaceAsync();
         await factory.CreateInvitationAsync(space.Id, "123456");
 
-        var response = await ExchangeTokenSimplifiedAsync(client, "654321", "Zoe");
+        var response = await ExchangeTokenAsync(client, "654321", "Zoe");
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -354,61 +343,14 @@ public class TokenEndpointTests
         await using var factory = new TestWebApplicationFactory();
         using var client = factory.CreateClient();
 
-        var response = await ExchangeTokenSimplifiedAsync(client, "123456", "Zoe");
+        var response = await ExchangeTokenAsync(client, "123456", "Zoe");
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
-    [Fact]
-    public async Task SimplifiedJoin_PinCollision_ReturnsConflict()
+    private static Task<HttpResponseMessage> ExchangeTokenAsync(HttpClient client, string pin, string displayName)
     {
-        await using var factory = new TestWebApplicationFactory();
-        using var client = factory.CreateClient();
-
-        var pin = "123456";
-        var space1 = await factory.CreateSpaceAsync("Space One");
-        var space2 = await factory.CreateSpaceAsync("Space Two");
-        await factory.CreateInvitationAsync(space1.Id, pin);
-        await factory.CreateInvitationAsync(space2.Id, pin);
-
-        var response = await ExchangeTokenSimplifiedAsync(client, pin, "Zoe");
-
-        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
-    }
-
-    [Fact]
-    public async Task SimplifiedJoin_WithExplicitSpaceId_BypassesCollisionCheck()
-    {
-        await using var factory = new TestWebApplicationFactory();
-        using var client = factory.CreateClient();
-
-        var pin = "123456";
-        var space1 = await factory.CreateSpaceAsync("Space One");
-        var space2 = await factory.CreateSpaceAsync("Space Two");
-        await factory.CreateInvitationAsync(space1.Id, pin);
-        await factory.CreateInvitationAsync(space2.Id, pin);
-
-        var response = await ExchangeTokenWithOptionalSpaceIdAsync(client, pin, "Zoe", space1.Id);
-
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var token = await ReadTokenAsync(response);
-        var payload = DecodeJwtPayload(token);
-        payload["space_id"].GetString().Should().Be(space1.Id.ToString());
-    }
-
-    private static Task<HttpResponseMessage> ExchangeTokenAsync(HttpClient client, Guid spaceId, string pin, string displayName)
-    {
-        return client.PostAsJsonAsync("/v1/tokens", new ExchangeTokenSimplifiedRequest(pin, displayName, spaceId));
-    }
-
-    private static Task<HttpResponseMessage> ExchangeTokenSimplifiedAsync(HttpClient client, string pin, string displayName)
-    {
-        return client.PostAsJsonAsync("/v1/tokens", new ExchangeTokenSimplifiedRequest(pin, displayName, null));
-    }
-
-    private static Task<HttpResponseMessage> ExchangeTokenWithOptionalSpaceIdAsync(HttpClient client, string pin, string displayName, Guid? spaceId)
-    {
-        return client.PostAsJsonAsync("/v1/tokens", new ExchangeTokenSimplifiedRequest(pin, displayName, spaceId));
+        return client.PostAsJsonAsync("/v1/tokens", new ExchangeTokenSimplifiedRequest(pin, displayName));
     }
 
     private static async Task<HttpResponseMessage> GetProtectedEndpointAsync(HttpClient client, string? token = null)
@@ -479,7 +421,7 @@ public class TokenEndpointTests
         return Convert.FromBase64String(padded);
     }
 
-    private sealed record ExchangeTokenSimplifiedRequest(string Pin, string DisplayName, Guid? SpaceId);
+    private sealed record ExchangeTokenSimplifiedRequest(string Pin, string DisplayName);
 
     private sealed record TokenResponse(string Token);
 


### PR DESCRIPTION
Removes `spaceId` from the token exchange flow entirely — both client and server. PINs are globally unique so the server resolves the space automatically via PIN-only lookup at `POST /v1/tokens`.

## Changes

### Server
- Simplified `CreateTokenRequest` to `(Pin, DisplayName)` — removed optional `SpaceId`
- Removed spaceId-based invitation lookup branch and collision detection from `TokenEndpoints`
- Removed tests for spaceId disambiguation, PIN collision (409), and non-existent space (404)

### Client
- Removed `spaceId` parameter from `exchangeToken()` — now `(serverUrl, pin, displayName)`
- Removed `spaceId` state property from `join-view.ts` (no UI field, no internal state)
- Removed 409 conflict error handler from `api-client.ts`
- Added 28 new tests for `join-view` component (previously untested)

## Verification

- ✅ Client build passes
- ✅ 593 client tests pass (565 existing + 28 new)
- ✅ 200 server tests pass

Closes #144
