### PR TITLE
feat(server): add journal sync endpoint

### DIFF
--- a/src/SharedSpaces.Server/Domain/DeletedItem.cs
+++ b/src/SharedSpaces.Server/Domain/DeletedItem.cs
@@ -1,0 +1,9 @@
+namespace SharedSpaces.Server.Domain;
+
+public class DeletedItem
+{
+    public Guid ItemId { get; set; }
+    public Guid SpaceId { get; set; }
+    public DateTime DeletedAt { get; set; } = DateTime.UtcNow;
+    public Space Space { get; set; } = null!;
+}

--- a/src/SharedSpaces.Server/Domain/Space.cs
+++ b/src/SharedSpaces.Server/Domain/Space.cs
@@ -6,7 +6,9 @@ public class Space
     public string Name { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public long? MaxUploadSize { get; set; }
+    public DateTime? JournalPrunedBefore { get; set; }
     public ICollection<SpaceInvitation> Invitations { get; set; } = [];
     public ICollection<SpaceMember> Members { get; set; } = [];
     public ICollection<SpaceItem> Items { get; set; } = [];
+    public ICollection<DeletedItem> DeletedItems { get; set; } = [];
 }

--- a/src/SharedSpaces.Server/Domain/SpaceMember.cs
+++ b/src/SharedSpaces.Server/Domain/SpaceMember.cs
@@ -7,6 +7,7 @@ public class SpaceMember
     public string DisplayName { get; set; } = string.Empty;
     public DateTime JoinedAt { get; set; } = DateTime.UtcNow;
     public bool IsRevoked { get; set; }
+    public DateTime? LastSyncAt { get; set; }
     public Space Space { get; set; } = null!;
     public ICollection<SpaceItem> Items { get; set; } = [];
 }

--- a/src/SharedSpaces.Server/Features/Items/ItemEndpoints.cs
+++ b/src/SharedSpaces.Server/Features/Items/ItemEndpoints.cs
@@ -422,12 +422,7 @@ public static class ItemEndpoints
 
         if (hasJournalSubscribers)
         {
-            db.DeletedItems.Add(new DeletedItem
-            {
-                ItemId = item.Id,
-                SpaceId = item.SpaceId,
-                DeletedAt = DateTime.UtcNow
-            });
+            await UpsertDeletedItemAsync(db, item.Id, item.SpaceId, cancellationToken);
         }
 
         await db.SaveChangesAsync(cancellationToken);
@@ -717,15 +712,15 @@ public static class ItemEndpoints
 
                     if (hasJournalSubscribers)
                     {
-                        db.DeletedItems.Add(new DeletedItem
-                        {
-                            ItemId = sourceItemTracked.Id,
-                            SpaceId = sourceItemTracked.SpaceId,
-                            DeletedAt = DateTime.UtcNow
-                        });
+                        await UpsertDeletedItemAsync(db, sourceItemTracked.Id, sourceItemTracked.SpaceId, cancellationToken);
                     }
 
                     await db.SaveChangesAsync(cancellationToken);
+
+                    if (hasJournalSubscribers)
+                    {
+                        await PruneDeletedItemsAsync(db, spaceId, journalOptions.Value, cancellationToken);
+                    }
                 }
 
                 var itemDeletedEvent = new ItemDeletedEvent(itemId, spaceId);
@@ -909,6 +904,8 @@ public static class ItemEndpoints
                     : sourceItem.Content;
             }
 
+            var hasJournalSubscribers = false;
+
             // If move, delete source item
             if (action == "move")
             {
@@ -920,17 +917,12 @@ public static class ItemEndpoints
                     db.SpaceItems.Remove(sourceItemTracked);
 
                     // Only write journal tombstone if at least one member has opted into journaling
-                    var hasJournalSubscribers = await db.SpaceMembers
+                    hasJournalSubscribers = await db.SpaceMembers
                         .AnyAsync(m => m.SpaceId == spaceId && m.LastSyncAt != null, cancellationToken);
 
                     if (hasJournalSubscribers)
                     {
-                        db.DeletedItems.Add(new DeletedItem
-                        {
-                            ItemId = sourceItemTracked.Id,
-                            SpaceId = sourceItemTracked.SpaceId,
-                            DeletedAt = DateTime.UtcNow
-                        });
+                        await UpsertDeletedItemAsync(db, sourceItemTracked.Id, sourceItemTracked.SpaceId, cancellationToken);
                     }
                 }
             }
@@ -976,7 +968,10 @@ public static class ItemEndpoints
                 }
 
                 // Prune old journal entries if configured
-                await PruneDeletedItemsAsync(db, spaceId, journalOptions.Value, cancellationToken);
+                if (hasJournalSubscribers)
+                {
+                    await PruneDeletedItemsAsync(db, spaceId, journalOptions.Value, cancellationToken);
+                }
             }
 
             var response = new SpaceItemResponse(
@@ -1024,6 +1019,31 @@ public static class ItemEndpoints
             {
                 await quotaLock.DisposeAsync();
             }
+        }
+    }
+
+    private static async Task UpsertDeletedItemAsync(
+        AppDbContext db,
+        Guid itemId,
+        Guid spaceId,
+        CancellationToken cancellationToken)
+    {
+        var existing = await db.DeletedItems
+            .SingleOrDefaultAsync(d => d.ItemId == itemId, cancellationToken);
+
+        if (existing is not null)
+        {
+            existing.SpaceId = spaceId;
+            existing.DeletedAt = DateTime.UtcNow;
+        }
+        else
+        {
+            db.DeletedItems.Add(new DeletedItem
+            {
+                ItemId = itemId,
+                SpaceId = spaceId,
+                DeletedAt = DateTime.UtcNow
+            });
         }
     }
 

--- a/src/SharedSpaces.Server/Features/Items/ItemEndpoints.cs
+++ b/src/SharedSpaces.Server/Features/Items/ItemEndpoints.cs
@@ -394,6 +394,7 @@ public static class ItemEndpoints
         AppDbContext db,
         IFileStorage fileStorage,
         ISpaceHubNotifier hubNotifier,
+        IConfiguration configuration,
         CancellationToken cancellationToken)
     {
         var authorizationResult = TryAuthorizeSpaceRequest(httpContext, spaceId, out _);
@@ -413,7 +414,18 @@ public static class ItemEndpoints
         var isFile = string.Equals(item.ContentType, "file", StringComparison.OrdinalIgnoreCase);
 
         db.SpaceItems.Remove(item);
+
+        db.DeletedItems.Add(new DeletedItem
+        {
+            ItemId = item.Id,
+            SpaceId = item.SpaceId,
+            DeletedAt = DateTime.UtcNow
+        });
+
         await db.SaveChangesAsync(cancellationToken);
+
+        // Prune old journal entries if over the limit
+        await PruneDeletedItemsAsync(db, spaceId, configuration, cancellationToken);
 
         var itemDeletedEvent = new ItemDeletedEvent(itemId, spaceId);
         await hubNotifier.NotifyItemDeletedAsync(itemDeletedEvent, cancellationToken);
@@ -877,6 +889,13 @@ public static class ItemEndpoints
                 if (sourceItemTracked is not null)
                 {
                     db.SpaceItems.Remove(sourceItemTracked);
+
+                    db.DeletedItems.Add(new DeletedItem
+                    {
+                        ItemId = sourceItemTracked.Id,
+                        SpaceId = sourceItemTracked.SpaceId,
+                        DeletedAt = DateTime.UtcNow
+                    });
                 }
             }
 
@@ -919,6 +938,9 @@ public static class ItemEndpoints
                         // Best-effort cleanup
                     }
                 }
+
+                // Prune old journal entries if over the limit
+                await PruneDeletedItemsAsync(db, spaceId, configuration, cancellationToken);
             }
 
             var response = new SpaceItemResponse(
@@ -967,6 +989,48 @@ public static class ItemEndpoints
                 await quotaLock.DisposeAsync();
             }
         }
+    }
+
+    private static async Task PruneDeletedItemsAsync(
+        AppDbContext db,
+        Guid spaceId,
+        IConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        var maxEntries = configuration.GetValue("Journal:MaxEntriesPerSpace", 1000);
+
+        var count = await db.DeletedItems
+            .CountAsync(d => d.SpaceId == spaceId, cancellationToken);
+
+        if (count <= maxEntries)
+        {
+            return;
+        }
+
+        var excess = count - maxEntries;
+
+        var oldestEntries = await db.DeletedItems
+            .Where(d => d.SpaceId == spaceId)
+            .OrderBy(d => d.DeletedAt)
+            .Take(excess)
+            .ToListAsync(cancellationToken);
+
+        if (oldestEntries.Count == 0)
+        {
+            return;
+        }
+
+        var watermark = oldestEntries.Max(d => d.DeletedAt);
+
+        db.DeletedItems.RemoveRange(oldestEntries);
+
+        var space = await db.Spaces.SingleOrDefaultAsync(s => s.Id == spaceId, cancellationToken);
+        if (space is not null)
+        {
+            space.JournalPrunedBefore = watermark;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
     }
 
     private static IResult? TryAuthorizeSpaceRequest(HttpContext httpContext, Guid routeSpaceId, out Guid memberId)

--- a/src/SharedSpaces.Server/Features/Items/ItemEndpoints.cs
+++ b/src/SharedSpaces.Server/Features/Items/ItemEndpoints.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using SharedSpaces.Server.Domain;
 using SharedSpaces.Server.Features.Hubs;
+using SharedSpaces.Server.Features.Journal;
 using SharedSpaces.Server.Features.Tokens;
 using SharedSpaces.Server.Infrastructure.FileStorage;
 using SharedSpaces.Server.Infrastructure.Persistence;
@@ -394,7 +395,7 @@ public static class ItemEndpoints
         AppDbContext db,
         IFileStorage fileStorage,
         ISpaceHubNotifier hubNotifier,
-        IConfiguration configuration,
+        IOptions<JournalOptions> journalOptions,
         CancellationToken cancellationToken)
     {
         var authorizationResult = TryAuthorizeSpaceRequest(httpContext, spaceId, out _);
@@ -415,17 +416,27 @@ public static class ItemEndpoints
 
         db.SpaceItems.Remove(item);
 
-        db.DeletedItems.Add(new DeletedItem
+        // Only write journal tombstone if at least one member has opted into journaling
+        var hasJournalSubscribers = await db.SpaceMembers
+            .AnyAsync(m => m.SpaceId == spaceId && m.LastSyncAt != null, cancellationToken);
+
+        if (hasJournalSubscribers)
         {
-            ItemId = item.Id,
-            SpaceId = item.SpaceId,
-            DeletedAt = DateTime.UtcNow
-        });
+            db.DeletedItems.Add(new DeletedItem
+            {
+                ItemId = item.Id,
+                SpaceId = item.SpaceId,
+                DeletedAt = DateTime.UtcNow
+            });
+        }
 
         await db.SaveChangesAsync(cancellationToken);
 
-        // Prune old journal entries if over the limit
-        await PruneDeletedItemsAsync(db, spaceId, configuration, cancellationToken);
+        // Prune old journal entries if configured
+        if (hasJournalSubscribers)
+        {
+            await PruneDeletedItemsAsync(db, spaceId, journalOptions.Value, cancellationToken);
+        }
 
         var itemDeletedEvent = new ItemDeletedEvent(itemId, spaceId);
         await hubNotifier.NotifyItemDeletedAsync(itemDeletedEvent, cancellationToken);
@@ -502,6 +513,7 @@ public static class ItemEndpoints
         IFileStorage fileStorage,
         IOptions<StorageOptions> storageOptions,
         ISpaceHubNotifier hubNotifier,
+        IOptions<JournalOptions> journalOptions,
         IConfiguration configuration,
         IHttpClientFactory httpClientFactory,
         CancellationToken cancellationToken)
@@ -551,12 +563,12 @@ public static class ItemEndpoints
         {
             return await TransferItemCrossServer(
                 spaceId, itemId, action, request.DestinationToken, jwtToken,
-                db, fileStorage, hubNotifier, httpClientFactory, cancellationToken);
+                db, fileStorage, hubNotifier, httpClientFactory, journalOptions, cancellationToken);
         }
 
         return await TransferItemSameServer(
             spaceId, itemId, action, request.DestinationToken,
-            httpContext, db, fileStorage, storageOptions, hubNotifier, configuration, cancellationToken);
+            httpContext, db, fileStorage, storageOptions, hubNotifier, configuration, journalOptions, cancellationToken);
     }
 
     private static bool IsSameServer(string sourceUrl, string? destinationUrl)
@@ -583,6 +595,7 @@ public static class ItemEndpoints
         IFileStorage fileStorage,
         ISpaceHubNotifier hubNotifier,
         IHttpClientFactory httpClientFactory,
+        IOptions<JournalOptions> journalOptions,
         CancellationToken cancellationToken)
     {
         var destinationServerUrl = jwtToken.Claims
@@ -697,6 +710,21 @@ public static class ItemEndpoints
                 if (sourceItemTracked is not null)
                 {
                     db.SpaceItems.Remove(sourceItemTracked);
+
+                    // Only write journal tombstone if at least one member has opted into journaling
+                    var hasJournalSubscribers = await db.SpaceMembers
+                        .AnyAsync(m => m.SpaceId == spaceId && m.LastSyncAt != null, cancellationToken);
+
+                    if (hasJournalSubscribers)
+                    {
+                        db.DeletedItems.Add(new DeletedItem
+                        {
+                            ItemId = sourceItemTracked.Id,
+                            SpaceId = sourceItemTracked.SpaceId,
+                            DeletedAt = DateTime.UtcNow
+                        });
+                    }
+
                     await db.SaveChangesAsync(cancellationToken);
                 }
 
@@ -737,6 +765,7 @@ public static class ItemEndpoints
         IOptions<StorageOptions> storageOptions,
         ISpaceHubNotifier hubNotifier,
         IConfiguration configuration,
+        IOptions<JournalOptions> journalOptions,
         CancellationToken cancellationToken)
     {
         // Validate destination token with signature verification (same server = same signing key)
@@ -890,12 +919,19 @@ public static class ItemEndpoints
                 {
                     db.SpaceItems.Remove(sourceItemTracked);
 
-                    db.DeletedItems.Add(new DeletedItem
+                    // Only write journal tombstone if at least one member has opted into journaling
+                    var hasJournalSubscribers = await db.SpaceMembers
+                        .AnyAsync(m => m.SpaceId == spaceId && m.LastSyncAt != null, cancellationToken);
+
+                    if (hasJournalSubscribers)
                     {
-                        ItemId = sourceItemTracked.Id,
-                        SpaceId = sourceItemTracked.SpaceId,
-                        DeletedAt = DateTime.UtcNow
-                    });
+                        db.DeletedItems.Add(new DeletedItem
+                        {
+                            ItemId = sourceItemTracked.Id,
+                            SpaceId = sourceItemTracked.SpaceId,
+                            DeletedAt = DateTime.UtcNow
+                        });
+                    }
                 }
             }
 
@@ -939,8 +975,8 @@ public static class ItemEndpoints
                     }
                 }
 
-                // Prune old journal entries if over the limit
-                await PruneDeletedItemsAsync(db, spaceId, configuration, cancellationToken);
+                // Prune old journal entries if configured
+                await PruneDeletedItemsAsync(db, spaceId, journalOptions.Value, cancellationToken);
             }
 
             var response = new SpaceItemResponse(
@@ -994,10 +1030,13 @@ public static class ItemEndpoints
     private static async Task PruneDeletedItemsAsync(
         AppDbContext db,
         Guid spaceId,
-        IConfiguration configuration,
+        JournalOptions journalOptions,
         CancellationToken cancellationToken)
     {
-        var maxEntries = configuration.GetValue("Journal:MaxEntriesPerSpace", 1000);
+        if (journalOptions.MaxEntriesPerSpace is not { } maxEntries)
+        {
+            return;
+        }
 
         var count = await db.DeletedItems
             .CountAsync(d => d.SpaceId == spaceId, cancellationToken);

--- a/src/SharedSpaces.Server/Features/Journal/JournalEndpoints.cs
+++ b/src/SharedSpaces.Server/Features/Journal/JournalEndpoints.cs
@@ -14,6 +14,8 @@ public static class JournalEndpoints
             .RequireAuthorization();
 
         group.MapGet("/", GetJournal);
+        group.MapPost("/checkpoint", UpdateCheckpoint);
+        group.MapDelete("/checkpoint", ResetCheckpoint);
 
         return app;
     }
@@ -22,8 +24,7 @@ public static class JournalEndpoints
         Guid spaceId,
         HttpContext httpContext,
         AppDbContext db,
-        CancellationToken cancellationToken,
-        DateTimeOffset? since = null)
+        CancellationToken cancellationToken)
     {
         var authorizationResult = TryAuthorizeSpaceRequest(httpContext, spaceId, out var memberId);
         if (authorizationResult is not null)
@@ -40,7 +41,23 @@ public static class JournalEndpoints
             return Results.NotFound(new { Error = "Space not found" });
         }
 
-        var sinceUtc = since?.UtcDateTime ?? DateTime.MinValue;
+        var member = await db.SpaceMembers
+            .SingleOrDefaultAsync(m => m.Id == memberId && m.SpaceId == spaceId, cancellationToken);
+
+        if (member is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (member.LastSyncAt is null)
+        {
+            // Enroll the member into journaling without acknowledging any progress yet.
+            member.LastSyncAt = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+            await db.SaveChangesAsync(cancellationToken);
+        }
+
+        var sinceUtc = DateTime.SpecifyKind(member.LastSyncAt.Value, DateTimeKind.Utc);
+        var checkpointUtc = DateTime.UtcNow;
         var fullSyncRequired = space.JournalPrunedBefore.HasValue && sinceUtc <= space.JournalPrunedBefore.Value;
 
         var addedOrUpdated = await db.SpaceItems
@@ -72,17 +89,80 @@ public static class JournalEndpoints
                 .ToArrayAsync(cancellationToken);
         }
 
-        // Update requesting member's LastSyncAt
+        return Results.Ok(new JournalResponse(fullSyncRequired, checkpointUtc, addedOrUpdated, deleted));
+    }
+
+    private static async Task<IResult> UpdateCheckpoint(
+        Guid spaceId,
+        JournalCheckpointRequest request,
+        HttpContext httpContext,
+        AppDbContext db,
+        CancellationToken cancellationToken)
+    {
+        var authorizationResult = TryAuthorizeSpaceRequest(httpContext, spaceId, out var memberId);
+        if (authorizationResult is not null)
+        {
+            return authorizationResult;
+        }
+
+        if (request.Checkpoint == default)
+        {
+            return Results.BadRequest(new { Error = "The 'checkpoint' value is required." });
+        }
+
+        if (request.Checkpoint.Kind == DateTimeKind.Local)
+        {
+            return Results.BadRequest(new { Error = "The 'checkpoint' value must be in UTC." });
+        }
+
+        var checkpointUtc = request.Checkpoint.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(request.Checkpoint, DateTimeKind.Utc)
+            : request.Checkpoint.ToUniversalTime();
+
         var member = await db.SpaceMembers
             .SingleOrDefaultAsync(m => m.Id == memberId && m.SpaceId == spaceId, cancellationToken);
 
-        if (member is not null)
+        if (member is null)
         {
-            member.LastSyncAt = DateTime.UtcNow;
+            return Results.Unauthorized();
+        }
+
+        if (member.LastSyncAt is null || checkpointUtc > member.LastSyncAt.Value)
+        {
+            member.LastSyncAt = checkpointUtc;
             await db.SaveChangesAsync(cancellationToken);
         }
 
-        return Results.Ok(new JournalResponse(fullSyncRequired, addedOrUpdated, deleted));
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> ResetCheckpoint(
+        Guid spaceId,
+        HttpContext httpContext,
+        AppDbContext db,
+        CancellationToken cancellationToken)
+    {
+        var authorizationResult = TryAuthorizeSpaceRequest(httpContext, spaceId, out var memberId);
+        if (authorizationResult is not null)
+        {
+            return authorizationResult;
+        }
+
+        var member = await db.SpaceMembers
+            .SingleOrDefaultAsync(m => m.Id == memberId && m.SpaceId == spaceId, cancellationToken);
+
+        if (member is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (member.LastSyncAt is not null)
+        {
+            member.LastSyncAt = null;
+            await db.SaveChangesAsync(cancellationToken);
+        }
+
+        return Results.NoContent();
     }
 
     private static IResult? TryAuthorizeSpaceRequest(HttpContext httpContext, Guid routeSpaceId, out Guid memberId)

--- a/src/SharedSpaces.Server/Features/Journal/JournalEndpoints.cs
+++ b/src/SharedSpaces.Server/Features/Journal/JournalEndpoints.cs
@@ -31,6 +31,12 @@ public static class JournalEndpoints
             return authorizationResult;
         }
 
+        // Treat Unspecified as UTC; reject ambiguous local-time offsets
+        if (since.HasValue && since.Value.Kind == DateTimeKind.Local)
+        {
+            return Results.BadRequest(new { Error = "The 'since' parameter must be in UTC (use Z suffix or no offset)." });
+        }
+
         var space = await db.Spaces
             .AsNoTracking()
             .SingleOrDefaultAsync(s => s.Id == spaceId, cancellationToken);
@@ -40,7 +46,9 @@ public static class JournalEndpoints
             return Results.NotFound(new { Error = "Space not found" });
         }
 
-        var sinceUtc = since?.ToUniversalTime() ?? DateTime.MinValue;
+        var sinceUtc = since.HasValue
+            ? DateTime.SpecifyKind(since.Value, DateTimeKind.Utc)
+            : DateTime.MinValue;
         var fullSyncRequired = space.JournalPrunedBefore.HasValue && sinceUtc < space.JournalPrunedBefore.Value;
 
         var addedOrUpdated = await db.SpaceItems

--- a/src/SharedSpaces.Server/Features/Journal/JournalEndpoints.cs
+++ b/src/SharedSpaces.Server/Features/Journal/JournalEndpoints.cs
@@ -1,0 +1,108 @@
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.EntityFrameworkCore;
+using SharedSpaces.Server.Features.Items;
+using SharedSpaces.Server.Features.Tokens;
+using SharedSpaces.Server.Infrastructure.Persistence;
+
+namespace SharedSpaces.Server.Features.Journal;
+
+public static class JournalEndpoints
+{
+    public static IEndpointRouteBuilder MapJournalEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/v1/spaces/{spaceId:guid}/journal")
+            .RequireAuthorization();
+
+        group.MapGet("/", GetJournal);
+
+        return app;
+    }
+
+    private static async Task<IResult> GetJournal(
+        Guid spaceId,
+        HttpContext httpContext,
+        AppDbContext db,
+        CancellationToken cancellationToken,
+        DateTime? since = null)
+    {
+        var authorizationResult = TryAuthorizeSpaceRequest(httpContext, spaceId, out var memberId);
+        if (authorizationResult is not null)
+        {
+            return authorizationResult;
+        }
+
+        var space = await db.Spaces
+            .AsNoTracking()
+            .SingleOrDefaultAsync(s => s.Id == spaceId, cancellationToken);
+
+        if (space is null)
+        {
+            return Results.NotFound(new { Error = "Space not found" });
+        }
+
+        var sinceUtc = since?.ToUniversalTime() ?? DateTime.MinValue;
+        var fullSyncRequired = space.JournalPrunedBefore.HasValue && sinceUtc < space.JournalPrunedBefore.Value;
+
+        var addedOrUpdated = await db.SpaceItems
+            .AsNoTracking()
+            .Where(item => item.SpaceId == spaceId && item.SharedAt >= sinceUtc)
+            .OrderBy(item => item.SharedAt)
+            .Select(item => new SpaceItemResponse(
+                item.Id,
+                item.SpaceId,
+                item.MemberId,
+                item.ContentType,
+                item.Content,
+                item.FileSize,
+                item.SharedAt))
+            .ToArrayAsync(cancellationToken);
+
+        Guid[] deleted;
+        if (fullSyncRequired)
+        {
+            deleted = [];
+        }
+        else
+        {
+            deleted = await db.DeletedItems
+                .AsNoTracking()
+                .Where(d => d.SpaceId == spaceId && d.DeletedAt >= sinceUtc)
+                .OrderBy(d => d.DeletedAt)
+                .Select(d => d.ItemId)
+                .ToArrayAsync(cancellationToken);
+        }
+
+        // Update requesting member's LastSyncAt
+        var member = await db.SpaceMembers
+            .SingleOrDefaultAsync(m => m.Id == memberId && m.SpaceId == spaceId, cancellationToken);
+
+        if (member is not null)
+        {
+            member.LastSyncAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(cancellationToken);
+        }
+
+        return Results.Ok(new JournalResponse(fullSyncRequired, addedOrUpdated, deleted));
+    }
+
+    private static IResult? TryAuthorizeSpaceRequest(HttpContext httpContext, Guid routeSpaceId, out Guid memberId)
+    {
+        memberId = Guid.Empty;
+
+        var memberClaim = httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+        if (!Guid.TryParse(memberClaim, out memberId) || memberId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var spaceClaim = httpContext.User.FindFirst(SpaceMemberClaimTypes.SpaceId)?.Value;
+        if (!Guid.TryParse(spaceClaim, out var claimedSpaceId))
+        {
+            return Results.Unauthorized();
+        }
+
+        return claimedSpaceId == routeSpaceId
+            ? null
+            : Results.Forbid();
+    }
+}

--- a/src/SharedSpaces.Server/Features/Journal/JournalEndpoints.cs
+++ b/src/SharedSpaces.Server/Features/Journal/JournalEndpoints.cs
@@ -23,18 +23,12 @@ public static class JournalEndpoints
         HttpContext httpContext,
         AppDbContext db,
         CancellationToken cancellationToken,
-        DateTime? since = null)
+        DateTimeOffset? since = null)
     {
         var authorizationResult = TryAuthorizeSpaceRequest(httpContext, spaceId, out var memberId);
         if (authorizationResult is not null)
         {
             return authorizationResult;
-        }
-
-        // Treat Unspecified as UTC; reject ambiguous local-time offsets
-        if (since.HasValue && since.Value.Kind == DateTimeKind.Local)
-        {
-            return Results.BadRequest(new { Error = "The 'since' parameter must be in UTC (use Z suffix or no offset)." });
         }
 
         var space = await db.Spaces
@@ -46,10 +40,8 @@ public static class JournalEndpoints
             return Results.NotFound(new { Error = "Space not found" });
         }
 
-        var sinceUtc = since.HasValue
-            ? DateTime.SpecifyKind(since.Value, DateTimeKind.Utc)
-            : DateTime.MinValue;
-        var fullSyncRequired = space.JournalPrunedBefore.HasValue && sinceUtc < space.JournalPrunedBefore.Value;
+        var sinceUtc = since?.UtcDateTime ?? DateTime.MinValue;
+        var fullSyncRequired = space.JournalPrunedBefore.HasValue && sinceUtc <= space.JournalPrunedBefore.Value;
 
         var addedOrUpdated = await db.SpaceItems
             .AsNoTracking()

--- a/src/SharedSpaces.Server/Features/Journal/JournalEndpoints.cs
+++ b/src/SharedSpaces.Server/Features/Journal/JournalEndpoints.cs
@@ -60,27 +60,29 @@ public static class JournalEndpoints
         var checkpointUtc = DateTime.UtcNow;
         var fullSyncRequired = space.JournalPrunedBefore.HasValue && sinceUtc <= space.JournalPrunedBefore.Value;
 
-        var addedOrUpdated = await db.SpaceItems
-            .AsNoTracking()
-            .Where(item => item.SpaceId == spaceId && item.SharedAt >= sinceUtc)
-            .OrderBy(item => item.SharedAt)
-            .Select(item => new SpaceItemResponse(
-                item.Id,
-                item.SpaceId,
-                item.MemberId,
-                item.ContentType,
-                item.Content,
-                item.FileSize,
-                item.SharedAt))
-            .ToArrayAsync(cancellationToken);
-
+        SpaceItemResponse[] addedOrUpdated;
         Guid[] deleted;
         if (fullSyncRequired)
         {
+            addedOrUpdated = [];
             deleted = [];
         }
         else
         {
+            addedOrUpdated = await db.SpaceItems
+                .AsNoTracking()
+                .Where(item => item.SpaceId == spaceId && item.SharedAt >= sinceUtc)
+                .OrderBy(item => item.SharedAt)
+                .Select(item => new SpaceItemResponse(
+                    item.Id,
+                    item.SpaceId,
+                    item.MemberId,
+                    item.ContentType,
+                    item.Content,
+                    item.FileSize,
+                    item.SharedAt))
+                .ToArrayAsync(cancellationToken);
+
             deleted = await db.DeletedItems
                 .AsNoTracking()
                 .Where(d => d.SpaceId == spaceId && d.DeletedAt >= sinceUtc)
@@ -110,14 +112,7 @@ public static class JournalEndpoints
             return Results.BadRequest(new { Error = "The 'checkpoint' value is required." });
         }
 
-        if (request.Checkpoint.Kind == DateTimeKind.Local)
-        {
-            return Results.BadRequest(new { Error = "The 'checkpoint' value must be in UTC." });
-        }
-
-        var checkpointUtc = request.Checkpoint.Kind == DateTimeKind.Unspecified
-            ? DateTime.SpecifyKind(request.Checkpoint, DateTimeKind.Utc)
-            : request.Checkpoint.ToUniversalTime();
+        var checkpointUtc = request.Checkpoint.UtcDateTime;
 
         var member = await db.SpaceMembers
             .SingleOrDefaultAsync(m => m.Id == memberId && m.SpaceId == spaceId, cancellationToken);

--- a/src/SharedSpaces.Server/Features/Journal/JournalOptions.cs
+++ b/src/SharedSpaces.Server/Features/Journal/JournalOptions.cs
@@ -1,0 +1,6 @@
+namespace SharedSpaces.Server.Features.Journal;
+
+public sealed class JournalOptions
+{
+    public int? MaxEntriesPerSpace { get; set; }
+}

--- a/src/SharedSpaces.Server/Features/Journal/Models.cs
+++ b/src/SharedSpaces.Server/Features/Journal/Models.cs
@@ -9,4 +9,4 @@ public sealed record JournalResponse(
     Guid[] Deleted);
 
 public sealed record JournalCheckpointRequest(
-    DateTime Checkpoint);
+    DateTimeOffset Checkpoint);

--- a/src/SharedSpaces.Server/Features/Journal/Models.cs
+++ b/src/SharedSpaces.Server/Features/Journal/Models.cs
@@ -4,5 +4,9 @@ namespace SharedSpaces.Server.Features.Journal;
 
 public sealed record JournalResponse(
     bool FullSyncRequired,
+    DateTime Checkpoint,
     SpaceItemResponse[] AddedOrUpdated,
     Guid[] Deleted);
+
+public sealed record JournalCheckpointRequest(
+    DateTime Checkpoint);

--- a/src/SharedSpaces.Server/Features/Journal/Models.cs
+++ b/src/SharedSpaces.Server/Features/Journal/Models.cs
@@ -1,0 +1,8 @@
+using SharedSpaces.Server.Features.Items;
+
+namespace SharedSpaces.Server.Features.Journal;
+
+public sealed record JournalResponse(
+    bool FullSyncRequired,
+    SpaceItemResponse[] AddedOrUpdated,
+    Guid[] Deleted);

--- a/src/SharedSpaces.Server/Infrastructure/Persistence/AppDbContext.cs
+++ b/src/SharedSpaces.Server/Infrastructure/Persistence/AppDbContext.cs
@@ -10,6 +10,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<SpaceMember> SpaceMembers => Set<SpaceMember>();
     public DbSet<SpaceItem> SpaceItems => Set<SpaceItem>();
     public DbSet<SharedLink> SharedLinks => Set<SharedLink>();
+    public DbSet<DeletedItem> DeletedItems => Set<DeletedItem>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/SharedSpaces.Server/Infrastructure/Persistence/Configurations/DeletedItemConfiguration.cs
+++ b/src/SharedSpaces.Server/Infrastructure/Persistence/Configurations/DeletedItemConfiguration.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SharedSpaces.Server.Domain;
+
+namespace SharedSpaces.Server.Infrastructure.Persistence.Configurations;
+
+public class DeletedItemConfiguration : IEntityTypeConfiguration<DeletedItem>
+{
+    public void Configure(EntityTypeBuilder<DeletedItem> builder)
+    {
+        builder.ToTable("DeletedItems");
+
+        builder.HasKey(d => d.ItemId);
+
+        builder.Property(d => d.ItemId)
+            .ValueGeneratedNever();
+
+        builder.Property(d => d.DeletedAt)
+            .IsRequired();
+
+        builder.HasIndex(d => new { d.SpaceId, d.DeletedAt });
+
+        builder.HasOne(d => d.Space)
+            .WithMany(s => s.DeletedItems)
+            .HasForeignKey(d => d.SpaceId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/SharedSpaces.Server/Infrastructure/Persistence/Configurations/SpaceConfiguration.cs
+++ b/src/SharedSpaces.Server/Infrastructure/Persistence/Configurations/SpaceConfiguration.cs
@@ -24,5 +24,8 @@ public class SpaceConfiguration : IEntityTypeConfiguration<Space>
 
         builder.Property(space => space.MaxUploadSize)
             .IsRequired(false);
+
+        builder.Property(space => space.JournalPrunedBefore)
+            .IsRequired(false);
     }
 }

--- a/src/SharedSpaces.Server/Infrastructure/Persistence/Configurations/SpaceMemberConfiguration.cs
+++ b/src/SharedSpaces.Server/Infrastructure/Persistence/Configurations/SpaceMemberConfiguration.cs
@@ -26,6 +26,9 @@ public class SpaceMemberConfiguration : IEntityTypeConfiguration<SpaceMember>
             .HasDefaultValue(false)
             .IsRequired();
 
+        builder.Property(member => member.LastSyncAt)
+            .IsRequired(false);
+
         builder.HasIndex(member => member.SpaceId);
 
         builder.HasOne(member => member.Space)

--- a/src/SharedSpaces.Server/Infrastructure/Persistence/Migrations/20260401094203_AddJournal.Designer.cs
+++ b/src/SharedSpaces.Server/Infrastructure/Persistence/Migrations/20260401094203_AddJournal.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SharedSpaces.Server.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using SharedSpaces.Server.Infrastructure.Persistence;
 namespace SharedSpaces.Server.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260401094203_AddJournal")]
+    partial class AddJournal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.0");

--- a/src/SharedSpaces.Server/Infrastructure/Persistence/Migrations/20260401094203_AddJournal.cs
+++ b/src/SharedSpaces.Server/Infrastructure/Persistence/Migrations/20260401094203_AddJournal.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SharedSpaces.Server.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddJournal : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "JournalPrunedBefore",
+                table: "Spaces",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastSyncAt",
+                table: "SpaceMembers",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "DeletedItems",
+                columns: table => new
+                {
+                    ItemId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    SpaceId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DeletedItems", x => x.ItemId);
+                    table.ForeignKey(
+                        name: "FK_DeletedItems_Spaces_SpaceId",
+                        column: x => x.SpaceId,
+                        principalTable: "Spaces",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeletedItems_SpaceId_DeletedAt",
+                table: "DeletedItems",
+                columns: new[] { "SpaceId", "DeletedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DeletedItems");
+
+            migrationBuilder.DropColumn(
+                name: "JournalPrunedBefore",
+                table: "Spaces");
+
+            migrationBuilder.DropColumn(
+                name: "LastSyncAt",
+                table: "SpaceMembers");
+        }
+    }
+}

--- a/src/SharedSpaces.Server/Program.cs
+++ b/src/SharedSpaces.Server/Program.cs
@@ -3,6 +3,7 @@ using SharedSpaces.Server.Features.Admin;
 using SharedSpaces.Server.Features.Hubs;
 using SharedSpaces.Server.Features.Invitations;
 using SharedSpaces.Server.Features.Items;
+using SharedSpaces.Server.Features.Journal;
 using SharedSpaces.Server.Features.SharedLinks;
 using SharedSpaces.Server.Features.Spaces;
 using SharedSpaces.Server.Features.Tokens;
@@ -75,6 +76,7 @@ app.MapSpaceEndpoints();
 app.MapInvitationEndpoints();
 app.MapTokenEndpoints();
 app.MapItemEndpoints();
+app.MapJournalEndpoints();
 app.MapSharedLinkEndpoints();
 app.MapHubEndpoints();
 

--- a/src/SharedSpaces.Server/Program.cs
+++ b/src/SharedSpaces.Server/Program.cs
@@ -10,6 +10,7 @@ using SharedSpaces.Server.Features.Tokens;
 using SharedSpaces.Server.Infrastructure;
 using SharedSpaces.Server.Infrastructure.FileStorage;
 using SharedSpaces.Server.Infrastructure.Persistence;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -23,6 +24,7 @@ builder.Services.AddOptions<StorageOptions>()
 builder.Services.AddSingleton<IFileStorage, LocalFileStorage>();
 builder.Services.AddHttpClient();
 builder.Services.AddSingleton<ISpaceHubNotifier, SpaceHubNotifier>();
+builder.Services.Configure<JournalOptions>(builder.Configuration.GetSection("Journal"));
 builder.Services.AddSignalR();
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {

--- a/src/SharedSpaces.Server/appsettings.json
+++ b/src/SharedSpaces.Server/appsettings.json
@@ -8,5 +8,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Journal": {
+    "MaxEntriesPerSpace": 1000
+  }
 }

--- a/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
+++ b/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
@@ -1,0 +1,596 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.IdentityModel.Tokens;
+using SharedSpaces.Server.Domain;
+using SharedSpaces.Server.Infrastructure.FileStorage;
+using SharedSpaces.Server.Infrastructure.Persistence;
+
+namespace SharedSpaces.Server.Tests;
+
+public class JournalEndpointTests
+{
+    [Fact]
+    public async Task GetJournal_ReturnsAddedItemsSinceTimestamp()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var beforeCreate = DateTime.UtcNow.AddSeconds(-1);
+
+        var item = await factory.CreateItemAsync(
+            space.Id, member.Id,
+            contentType: "text",
+            content: "hello journal",
+            sharedAt: DateTime.UtcNow,
+            fileSize: 0);
+
+        var response = await GetJournalAsync(client, space.Id, token, since: beforeCreate);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadJsonAsync<JournalResponse>(response);
+        body.FullSyncRequired.Should().BeFalse();
+        body.AddedOrUpdated.Should().ContainSingle(r => r.Id == item.Id);
+        body.Deleted.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetJournal_ReturnsDeletedItemIdsSinceTimestamp()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var item = await factory.CreateItemAsync(
+            space.Id, member.Id,
+            contentType: "text",
+            content: "to be deleted",
+            sharedAt: DateTime.UtcNow.AddMinutes(-5),
+            fileSize: 0);
+
+        var beforeDelete = DateTime.UtcNow.AddSeconds(-1);
+
+        // Delete the item via API
+        var deleteResponse = await DeleteItemAsync(client, space.Id, item.Id, token);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var response = await GetJournalAsync(client, space.Id, token, since: beforeDelete);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadJsonAsync<JournalResponse>(response);
+        body.FullSyncRequired.Should().BeFalse();
+        body.Deleted.Should().Contain(item.Id);
+    }
+
+    [Fact]
+    public async Task GetJournal_ReturnsFullSyncRequired_WhenSinceIsBeforePrunedWatermark()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        // Set the JournalPrunedBefore watermark directly
+        await factory.WithDbContextAsync(async db =>
+        {
+            var s = await db.Spaces.SingleAsync(s => s.Id == space.Id);
+            s.JournalPrunedBefore = DateTime.UtcNow.AddMinutes(-10);
+            await db.SaveChangesAsync();
+        });
+
+        // Query with a since before the watermark
+        var response = await GetJournalAsync(client, space.Id, token, since: DateTime.UtcNow.AddMinutes(-30));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadJsonAsync<JournalResponse>(response);
+        body.FullSyncRequired.Should().BeTrue();
+        body.Deleted.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetJournal_ReturnsFullSyncRequiredFalse_WhenJournalCoversWindow()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        // No pruning has happened — JournalPrunedBefore is null
+        var response = await GetJournalAsync(client, space.Id, token, since: DateTime.UtcNow.AddMinutes(-5));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadJsonAsync<JournalResponse>(response);
+        body.FullSyncRequired.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetJournal_UpdatesMemberLastSyncAt()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        // Verify LastSyncAt is initially null
+        await factory.WithDbContextAsync(async db =>
+        {
+            var m = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            m.LastSyncAt.Should().BeNull();
+        });
+
+        var beforeCall = DateTime.UtcNow;
+        var response = await GetJournalAsync(client, space.Id, token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var m = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            m.LastSyncAt.Should().NotBeNull();
+            m.LastSyncAt!.Value.Should().BeOnOrAfter(beforeCall);
+        });
+    }
+
+    [Fact]
+    public async Task GetJournal_EmptyJournal_ReturnsEmptyArrays()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var response = await GetJournalAsync(client, space.Id, token, since: DateTime.UtcNow);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadJsonAsync<JournalResponse>(response);
+        body.FullSyncRequired.Should().BeFalse();
+        body.AddedOrUpdated.Should().BeEmpty();
+        body.Deleted.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetJournal_WithoutJwt_Returns401()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+
+        var response = await GetJournalAsync(client, space.Id);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetJournal_NonExistentSpace_Returns404()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var nonExistentSpaceId = Guid.NewGuid();
+
+        // Create a member in a real space but use the token for the non-existent space
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, nonExistentSpaceId, member.DisplayName);
+
+        var response = await GetJournalAsync(client, nonExistentSpaceId, token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteItem_CreatesDeletedItemRecord()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var item = await factory.CreateItemAsync(
+            space.Id, member.Id,
+            contentType: "text",
+            content: "about to be deleted",
+            sharedAt: DateTime.UtcNow,
+            fileSize: 0);
+
+        var deleteResponse = await DeleteItemAsync(client, space.Id, item.Id, token);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var deletedItem = await db.DeletedItems.SingleOrDefaultAsync(d => d.ItemId == item.Id);
+            deletedItem.Should().NotBeNull();
+            deletedItem!.SpaceId.Should().Be(space.Id);
+            deletedItem.DeletedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        });
+    }
+
+    [Fact]
+    public async Task TransferItem_WithMoveAction_CreatesDeletedItemRecord()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        // Source space and member
+        var sourceSpace = await factory.CreateSpaceAsync("Source");
+        var sourceMember = await factory.CreateMemberAsync(sourceSpace.Id, "Zoe");
+        var sourceToken = GenerateTestJwt(sourceMember.Id, sourceSpace.Id, sourceMember.DisplayName);
+
+        // Destination space and member
+        var destSpace = await factory.CreateSpaceAsync("Destination");
+        var destMember = await factory.CreateMemberAsync(destSpace.Id, "Wash");
+        var destToken = GenerateTestJwt(destMember.Id, destSpace.Id, destMember.DisplayName);
+
+        var item = await factory.CreateItemAsync(
+            sourceSpace.Id, sourceMember.Id,
+            contentType: "text",
+            content: "moving item",
+            sharedAt: DateTime.UtcNow,
+            fileSize: 0);
+
+        var transferResponse = await TransferItemAsync(
+            client, sourceSpace.Id, item.Id, sourceToken,
+            destinationToken: destToken, action: "move");
+        transferResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var deletedItem = await db.DeletedItems.SingleOrDefaultAsync(d => d.ItemId == item.Id);
+            deletedItem.Should().NotBeNull();
+            deletedItem!.SpaceId.Should().Be(sourceSpace.Id);
+        });
+    }
+
+    [Fact]
+    public async Task Pruning_TrimsToConfiguredMaxAndUpdatesWatermark()
+    {
+        // Set max to 5 entries
+        await using var factory = new TestWebApplicationFactory(journalMaxEntries: 5);
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        // Create 6 items to delete (will exceed the max of 5)
+        var items = new List<SpaceItem>();
+        for (var i = 0; i < 6; i++)
+        {
+            var item = await factory.CreateItemAsync(
+                space.Id, member.Id,
+                contentType: "text",
+                content: $"item-{i}",
+                sharedAt: DateTime.UtcNow.AddMinutes(-30 + i),
+                fileSize: 0);
+            items.Add(item);
+        }
+
+        // Delete all items — each deletion adds a DeletedItem record
+        foreach (var item in items)
+        {
+            var deleteResponse = await DeleteItemAsync(client, space.Id, item.Id, token);
+            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+
+        // After 6 deletions with max=5, pruning should have trimmed to 5
+        await factory.WithDbContextAsync(async db =>
+        {
+            var deletedCount = await db.DeletedItems.CountAsync(d => d.SpaceId == space.Id);
+            deletedCount.Should().BeLessOrEqualTo(5);
+
+            var s = await db.Spaces.SingleAsync(s => s.Id == space.Id);
+            s.JournalPrunedBefore.Should().NotBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task GetJournal_WithoutSinceParameter_ReturnsAllItems()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var item1 = await factory.CreateItemAsync(
+            space.Id, member.Id,
+            contentType: "text",
+            content: "old item",
+            sharedAt: DateTime.UtcNow.AddDays(-7),
+            fileSize: 0);
+
+        var item2 = await factory.CreateItemAsync(
+            space.Id, member.Id,
+            contentType: "text",
+            content: "new item",
+            sharedAt: DateTime.UtcNow,
+            fileSize: 0);
+
+        // No since parameter → should return everything
+        var response = await GetJournalAsync(client, space.Id, token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadJsonAsync<JournalResponse>(response);
+        body.AddedOrUpdated.Should().HaveCount(2);
+        body.AddedOrUpdated.Should().Contain(r => r.Id == item1.Id);
+        body.AddedOrUpdated.Should().Contain(r => r.Id == item2.Id);
+    }
+
+    // --- Helpers ---
+
+    private static async Task<HttpResponseMessage> GetJournalAsync(
+        HttpClient client, Guid spaceId, string? token = null, DateTime? since = null)
+    {
+        var url = $"/v1/spaces/{spaceId}/journal";
+        if (since.HasValue)
+        {
+            url += $"?since={since.Value:O}";
+        }
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        AddAuthorizationHeader(request, token);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> DeleteItemAsync(
+        HttpClient client, Guid spaceId, Guid itemId, string? token = null)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Delete, $"/v1/spaces/{spaceId}/items/{itemId}");
+        AddAuthorizationHeader(request, token);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> TransferItemAsync(
+        HttpClient client, Guid spaceId, Guid itemId, string sourceToken,
+        string destinationToken, string action)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"/v1/spaces/{spaceId}/items/{itemId}/transfer");
+        request.Content = JsonContent.Create(new { destinationToken, action });
+        AddAuthorizationHeader(request, sourceToken);
+        return await client.SendAsync(request);
+    }
+
+    private static void AddAuthorizationHeader(HttpRequestMessage request, string? token)
+    {
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+    }
+
+    private static string GenerateTestJwt(Guid memberId, Guid spaceId, string displayName = "TestUser")
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestWebApplicationFactory.JwtSigningKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            claims:
+            [
+                new Claim(JwtRegisteredClaimNames.Sub, memberId.ToString()),
+                new Claim("display_name", displayName),
+                new Claim("server_url", TestWebApplicationFactory.ServerUrl),
+                new Claim("space_id", spaceId.ToString())
+            ],
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private static async Task<T> ReadJsonAsync<T>(HttpResponseMessage response)
+    {
+        var body = await response.Content.ReadFromJsonAsync<T>();
+        body.Should().NotBeNull();
+        return body!;
+    }
+
+    private sealed record JournalResponse(
+        bool FullSyncRequired,
+        SpaceItemResponse[] AddedOrUpdated,
+        Guid[] Deleted);
+
+    private sealed record SpaceItemResponse(
+        Guid Id,
+        Guid SpaceId,
+        Guid MemberId,
+        string ContentType,
+        string Content,
+        long FileSize,
+        DateTime SharedAt);
+
+    private sealed class TestWebApplicationFactory(long? maxSpaceQuotaBytes = null, int? journalMaxEntries = null) : WebApplicationFactory<Program>
+    {
+        public const string AdminSecret = "test-admin-secret";
+        public const string JwtSigningKey = "test-signing-key-1234567890abcdef";
+        public const string ServerUrl = "https://sharedspaces.test";
+
+        private readonly string _databaseName = $"sharedspaces-journal-tests-{Guid.NewGuid()}";
+        private readonly long _maxSpaceQuotaBytes = maxSpaceQuotaBytes ?? 104_857_600;
+        private readonly int _journalMaxEntries = journalMaxEntries ?? 1000;
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Admin:Secret"] = AdminSecret,
+                    ["Jwt:SigningKey"] = JwtSigningKey,
+                    ["Storage:BasePath"] = "./artifacts/storage-journal-tests",
+                    ["Storage:MaxSpaceQuotaBytes"] = _maxSpaceQuotaBytes.ToString(),
+                    ["Journal:MaxEntriesPerSpace"] = _journalMaxEntries.ToString()
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<DbContextOptions<AppDbContext>>();
+                services.RemoveAll<IDbContextOptionsConfiguration<AppDbContext>>();
+                services.RemoveAll<AppDbContext>();
+                services.RemoveAll<IFileStorage>();
+
+                services.AddDbContext<AppDbContext>(options => options.UseInMemoryDatabase(_databaseName));
+                services.AddSingleton<IFileStorage>(_ => new InMemoryFileStorage());
+            });
+        }
+
+        public async Task<Space> CreateSpaceAsync(string name = "Test Space", long? maxUploadSize = null)
+        {
+            return await WithDbContextAsync(async db =>
+            {
+                var space = new Space
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name,
+                    MaxUploadSize = maxUploadSize
+                };
+
+                db.Spaces.Add(space);
+                await db.SaveChangesAsync();
+                return space;
+            });
+        }
+
+        public async Task<SpaceMember> CreateMemberAsync(Guid spaceId, string displayName = "TestUser", Guid? memberId = null)
+        {
+            return await WithDbContextAsync(async db =>
+            {
+                var member = new SpaceMember
+                {
+                    Id = memberId ?? Guid.NewGuid(),
+                    SpaceId = spaceId,
+                    DisplayName = displayName,
+                    JoinedAt = DateTime.UtcNow,
+                    IsRevoked = false
+                };
+
+                db.SpaceMembers.Add(member);
+                await db.SaveChangesAsync();
+                return member;
+            });
+        }
+
+        public async Task<SpaceItem> CreateItemAsync(
+            Guid spaceId,
+            Guid memberId,
+            string contentType,
+            string content,
+            DateTime sharedAt,
+            long fileSize,
+            Guid? itemId = null)
+        {
+            return await WithDbContextAsync(async db =>
+            {
+                var item = new SpaceItem(itemId ?? Guid.NewGuid())
+                {
+                    SpaceId = spaceId,
+                    MemberId = memberId,
+                    ContentType = contentType,
+                    Content = content,
+                    SharedAt = sharedAt,
+                    FileSize = fileSize
+                };
+
+                db.SpaceItems.Add(item);
+                await db.SaveChangesAsync();
+                return item;
+            });
+        }
+
+        public async Task WithDbContextAsync(Func<AppDbContext, Task> action)
+        {
+            using var scope = Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            await action(db);
+        }
+
+        public async Task<T> WithDbContextAsync<T>(Func<AppDbContext, Task<T>> action)
+        {
+            using var scope = Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            return await action(db);
+        }
+
+        private sealed class InMemoryFileStorage : IFileStorage
+        {
+            private readonly object _syncRoot = new();
+            private readonly Dictionary<string, byte[]> _files = new(StringComparer.OrdinalIgnoreCase);
+
+            private static string GetKey(Guid spaceId, Guid itemId) => $"{spaceId:N}/{itemId:N}";
+
+            public async Task SaveAsync(Guid spaceId, Guid itemId, Stream content, CancellationToken ct)
+            {
+                ct.ThrowIfCancellationRequested();
+                ArgumentNullException.ThrowIfNull(content);
+
+                await using var buffer = new MemoryStream();
+                await content.CopyToAsync(buffer, ct);
+                var key = GetKey(spaceId, itemId);
+
+                lock (_syncRoot)
+                {
+                    _files[key] = buffer.ToArray();
+                }
+            }
+
+            public Task<Stream> ReadAsync(Guid spaceId, Guid itemId, CancellationToken ct)
+            {
+                ct.ThrowIfCancellationRequested();
+                var key = GetKey(spaceId, itemId);
+
+                lock (_syncRoot)
+                {
+                    if (!_files.TryGetValue(key, out var bytes))
+                    {
+                        throw new FileNotFoundException($"Stored file '{key}' was not found.", key);
+                    }
+
+                    return Task.FromResult<Stream>(new MemoryStream(bytes));
+                }
+            }
+
+            public Task DeleteAsync(Guid spaceId, Guid itemId, CancellationToken ct)
+            {
+                ct.ThrowIfCancellationRequested();
+                var key = GetKey(spaceId, itemId);
+
+                lock (_syncRoot)
+                {
+                    _files.Remove(key);
+                }
+
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
+++ b/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
@@ -264,6 +264,142 @@ public class JournalEndpointTests
     }
 
     [Fact]
+    public async Task GetJournal_ReplaysSameChanges_UntilCheckpointIsAcknowledged()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var item = await factory.CreateItemAsync(
+            space.Id, member.Id,
+            contentType: "text",
+            content: "replay me",
+            sharedAt: DateTime.UtcNow,
+            fileSize: 0);
+
+        var first = await ReadJsonAsync<JournalResponse>(await GetJournalAsync(client, space.Id, token));
+        var second = await ReadJsonAsync<JournalResponse>(await GetJournalAsync(client, space.Id, token));
+
+        first.AddedOrUpdated.Should().ContainSingle(r => r.Id == item.Id);
+        second.AddedOrUpdated.Should().ContainSingle(r => r.Id == item.Id);
+        second.Checkpoint.Should().BeOnOrAfter(first.Checkpoint);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var trackedMember = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            trackedMember.LastSyncAt.Should().Be(DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc));
+        });
+    }
+
+    [Fact]
+    public async Task PostCheckpoint_StopsReplayingAcknowledgedItems()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var oldItem = await factory.CreateItemAsync(
+            space.Id, member.Id,
+            contentType: "text",
+            content: "already synced",
+            sharedAt: DateTime.UtcNow,
+            fileSize: 0);
+
+        var first = await ReadJsonAsync<JournalResponse>(await GetJournalAsync(client, space.Id, token));
+        await PostCheckpointAsync(client, space.Id, token, first.Checkpoint);
+
+        var newItem = await factory.CreateItemAsync(
+            space.Id, member.Id,
+            contentType: "text",
+            content: "new after ack",
+            sharedAt: first.Checkpoint.AddSeconds(1),
+            fileSize: 0);
+
+        var second = await ReadJsonAsync<JournalResponse>(await GetJournalAsync(client, space.Id, token));
+
+        second.AddedOrUpdated.Should().ContainSingle(r => r.Id == newItem.Id);
+        second.AddedOrUpdated.Should().NotContain(r => r.Id == oldItem.Id);
+    }
+
+    [Fact]
+    public async Task DeleteCheckpoint_MakesNextGetReplayFullBaseline()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var item = await factory.CreateItemAsync(
+            space.Id, member.Id,
+            contentType: "text",
+            content: "baseline item",
+            sharedAt: DateTime.UtcNow.AddMinutes(-5),
+            fileSize: 0);
+
+        var initial = await ReadJsonAsync<JournalResponse>(await GetJournalAsync(client, space.Id, token));
+        await PostCheckpointAsync(client, space.Id, token, initial.Checkpoint);
+
+        var resetResponse = await DeleteCheckpointAsync(client, space.Id, token);
+        resetResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var replay = await ReadJsonAsync<JournalResponse>(await GetJournalAsync(client, space.Id, token));
+        replay.AddedOrUpdated.Should().ContainSingle(r => r.Id == item.Id);
+    }
+
+    [Fact]
+    public async Task PostCheckpoint_DoesNotMoveStoredCheckpointBackward()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var currentCheckpoint = DateTime.UtcNow;
+        var olderCheckpoint = currentCheckpoint.AddMinutes(-5);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var trackedMember = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            trackedMember.LastSyncAt = currentCheckpoint;
+            await db.SaveChangesAsync();
+        });
+
+        var response = await PostCheckpointAsync(client, space.Id, token, olderCheckpoint);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var trackedMember = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            trackedMember.LastSyncAt.Should().Be(currentCheckpoint);
+        });
+    }
+
+    [Fact]
+    public async Task PostCheckpoint_WithDefaultCheckpoint_Returns400()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var response = await PostCheckpointAsync(client, space.Id, token, default);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task GetJournal_EmptyJournal_ReturnsEmptyArrays()
     {
         await using var factory = new TestWebApplicationFactory();

--- a/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
+++ b/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
@@ -59,6 +59,9 @@ public class JournalEndpointTests
         var member = await factory.CreateMemberAsync(space.Id, "Zoe");
         var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
 
+        // Opt member into journaling
+        await GetJournalAsync(client, space.Id, token);
+
         var item = await factory.CreateItemAsync(
             space.Id, member.Id,
             contentType: "text",
@@ -215,6 +218,9 @@ public class JournalEndpointTests
         var member = await factory.CreateMemberAsync(space.Id, "Zoe");
         var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
 
+        // Opt member into journaling by calling journal endpoint
+        await GetJournalAsync(client, space.Id, token);
+
         var item = await factory.CreateItemAsync(
             space.Id, member.Id,
             contentType: "text",
@@ -244,6 +250,9 @@ public class JournalEndpointTests
         var sourceSpace = await factory.CreateSpaceAsync("Source");
         var sourceMember = await factory.CreateMemberAsync(sourceSpace.Id, "Zoe");
         var sourceToken = GenerateTestJwt(sourceMember.Id, sourceSpace.Id, sourceMember.DisplayName);
+
+        // Opt source member into journaling
+        await GetJournalAsync(client, sourceSpace.Id, sourceToken);
 
         // Destination space and member
         var destSpace = await factory.CreateSpaceAsync("Destination");
@@ -281,6 +290,9 @@ public class JournalEndpointTests
         var member = await factory.CreateMemberAsync(space.Id, "Zoe");
         var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
 
+        // Opt member into journaling
+        await GetJournalAsync(client, space.Id, token);
+
         // Create 6 items to delete (will exceed the max of 5)
         var items = new List<SpaceItem>();
         for (var i = 0; i < 6; i++)
@@ -309,6 +321,35 @@ public class JournalEndpointTests
 
             var s = await db.Spaces.SingleAsync(s => s.Id == space.Id);
             s.JournalPrunedBefore.Should().NotBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task DeleteItem_DoesNotCreateDeletedItemRecord_WhenNoMemberOptedIn()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        // Do NOT opt into journaling (no journal call)
+
+        var item = await factory.CreateItemAsync(
+            space.Id, member.Id,
+            contentType: "text",
+            content: "deleted without journal",
+            sharedAt: DateTime.UtcNow,
+            fileSize: 0);
+
+        var deleteResponse = await DeleteItemAsync(client, space.Id, item.Id, token);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var deletedItem = await db.DeletedItems.SingleOrDefaultAsync(d => d.ItemId == item.Id);
+            deletedItem.Should().BeNull();
         });
     }
 
@@ -434,7 +475,6 @@ public class JournalEndpointTests
 
         private readonly string _databaseName = $"sharedspaces-journal-tests-{Guid.NewGuid()}";
         private readonly long _maxSpaceQuotaBytes = maxSpaceQuotaBytes ?? 104_857_600;
-        private readonly int _journalMaxEntries = journalMaxEntries ?? 1000;
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
@@ -442,14 +482,20 @@ public class JournalEndpointTests
 
             builder.ConfigureAppConfiguration((_, configBuilder) =>
             {
-                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                var config = new Dictionary<string, string?>
                 {
                     ["Admin:Secret"] = AdminSecret,
                     ["Jwt:SigningKey"] = JwtSigningKey,
                     ["Storage:BasePath"] = "./artifacts/storage-journal-tests",
-                    ["Storage:MaxSpaceQuotaBytes"] = _maxSpaceQuotaBytes.ToString(),
-                    ["Journal:MaxEntriesPerSpace"] = _journalMaxEntries.ToString()
-                });
+                    ["Storage:MaxSpaceQuotaBytes"] = _maxSpaceQuotaBytes.ToString()
+                };
+
+                if (journalMaxEntries.HasValue)
+                {
+                    config["Journal:MaxEntriesPerSpace"] = journalMaxEntries.Value.ToString();
+                }
+
+                configBuilder.AddInMemoryCollection(config);
             });
 
             builder.ConfigureServices(services =>

--- a/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
+++ b/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
@@ -128,6 +128,7 @@ public class JournalEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await ReadJsonAsync<JournalResponse>(response);
         body.FullSyncRequired.Should().BeTrue();
+        body.AddedOrUpdated.Should().BeEmpty();
         body.Deleted.Should().BeEmpty();
     }
 
@@ -157,6 +158,7 @@ public class JournalEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await ReadJsonAsync<JournalResponse>(response);
         body.FullSyncRequired.Should().BeTrue();
+        body.AddedOrUpdated.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
+++ b/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
@@ -111,6 +111,33 @@ public class JournalEndpointTests
     }
 
     [Fact]
+    public async Task GetJournal_ReturnsFullSyncRequired_WhenSinceEqualsWatermark()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var watermark = DateTime.UtcNow.AddMinutes(-10);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var s = await db.Spaces.SingleAsync(s => s.Id == space.Id);
+            s.JournalPrunedBefore = watermark;
+            await db.SaveChangesAsync();
+        });
+
+        // Query with since == watermark — boundary should require full sync
+        var response = await GetJournalAsync(client, space.Id, token, since: watermark);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadJsonAsync<JournalResponse>(response);
+        body.FullSyncRequired.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task GetJournal_ReturnsFullSyncRequiredFalse_WhenJournalCoversWindow()
     {
         await using var factory = new TestWebApplicationFactory();
@@ -390,12 +417,12 @@ public class JournalEndpointTests
     // --- Helpers ---
 
     private static async Task<HttpResponseMessage> GetJournalAsync(
-        HttpClient client, Guid spaceId, string? token = null, DateTime? since = null)
+        HttpClient client, Guid spaceId, string? token = null, DateTimeOffset? since = null)
     {
         var url = $"/v1/spaces/{spaceId}/journal";
         if (since.HasValue)
         {
-            url += $"?since={since.Value:O}";
+            url += $"?since={since.Value.UtcDateTime:O}";
         }
 
         using var request = new HttpRequestMessage(HttpMethod.Get, url);

--- a/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
+++ b/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
@@ -22,7 +22,7 @@ namespace SharedSpaces.Server.Tests;
 public class JournalEndpointTests
 {
     [Fact]
-    public async Task GetJournal_ReturnsAddedItemsSinceTimestamp()
+    public async Task GetJournal_ReturnsAddedItemsSinceStoredCheckpoint()
     {
         await using var factory = new TestWebApplicationFactory();
         using var client = factory.CreateClient();
@@ -31,7 +31,21 @@ public class JournalEndpointTests
         var member = await factory.CreateMemberAsync(space.Id, "Zoe");
         var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
 
-        var beforeCreate = DateTime.UtcNow.AddSeconds(-1);
+        var checkpoint = DateTime.UtcNow.AddMinutes(-1);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var trackedMember = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            trackedMember.LastSyncAt = checkpoint;
+            await db.SaveChangesAsync();
+        });
+
+        await factory.CreateItemAsync(
+            space.Id, member.Id,
+            contentType: "text",
+            content: "old item",
+            sharedAt: checkpoint.AddMinutes(-2),
+            fileSize: 0);
 
         var item = await factory.CreateItemAsync(
             space.Id, member.Id,
@@ -40,17 +54,18 @@ public class JournalEndpointTests
             sharedAt: DateTime.UtcNow,
             fileSize: 0);
 
-        var response = await GetJournalAsync(client, space.Id, token, since: beforeCreate);
+        var response = await GetJournalAsync(client, space.Id, token);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await ReadJsonAsync<JournalResponse>(response);
         body.FullSyncRequired.Should().BeFalse();
+        body.Checkpoint.Should().BeOnOrAfter(checkpoint);
         body.AddedOrUpdated.Should().ContainSingle(r => r.Id == item.Id);
         body.Deleted.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task GetJournal_ReturnsDeletedItemIdsSinceTimestamp()
+    public async Task GetJournal_ReturnsDeletedItemIdsSinceStoredCheckpoint()
     {
         await using var factory = new TestWebApplicationFactory();
         using var client = factory.CreateClient();
@@ -58,9 +73,6 @@ public class JournalEndpointTests
         var space = await factory.CreateSpaceAsync();
         var member = await factory.CreateMemberAsync(space.Id, "Zoe");
         var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
-
-        // Opt member into journaling
-        await GetJournalAsync(client, space.Id, token);
 
         var item = await factory.CreateItemAsync(
             space.Id, member.Id,
@@ -71,11 +83,18 @@ public class JournalEndpointTests
 
         var beforeDelete = DateTime.UtcNow.AddSeconds(-1);
 
+        await factory.WithDbContextAsync(async db =>
+        {
+            var trackedMember = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            trackedMember.LastSyncAt = beforeDelete;
+            await db.SaveChangesAsync();
+        });
+
         // Delete the item via API
         var deleteResponse = await DeleteItemAsync(client, space.Id, item.Id, token);
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        var response = await GetJournalAsync(client, space.Id, token, since: beforeDelete);
+        var response = await GetJournalAsync(client, space.Id, token);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await ReadJsonAsync<JournalResponse>(response);
@@ -84,7 +103,7 @@ public class JournalEndpointTests
     }
 
     [Fact]
-    public async Task GetJournal_ReturnsFullSyncRequired_WhenSinceIsBeforePrunedWatermark()
+    public async Task GetJournal_ReturnsFullSyncRequired_WhenCheckpointIsBeforePrunedWatermark()
     {
         await using var factory = new TestWebApplicationFactory();
         using var client = factory.CreateClient();
@@ -93,16 +112,18 @@ public class JournalEndpointTests
         var member = await factory.CreateMemberAsync(space.Id, "Zoe");
         var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
 
-        // Set the JournalPrunedBefore watermark directly
+        var checkpoint = DateTime.UtcNow.AddMinutes(-30);
+
         await factory.WithDbContextAsync(async db =>
         {
             var s = await db.Spaces.SingleAsync(s => s.Id == space.Id);
             s.JournalPrunedBefore = DateTime.UtcNow.AddMinutes(-10);
+            var trackedMember = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            trackedMember.LastSyncAt = checkpoint;
             await db.SaveChangesAsync();
         });
 
-        // Query with a since before the watermark
-        var response = await GetJournalAsync(client, space.Id, token, since: DateTime.UtcNow.AddMinutes(-30));
+        var response = await GetJournalAsync(client, space.Id, token);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await ReadJsonAsync<JournalResponse>(response);
@@ -111,7 +132,7 @@ public class JournalEndpointTests
     }
 
     [Fact]
-    public async Task GetJournal_ReturnsFullSyncRequired_WhenSinceEqualsWatermark()
+    public async Task GetJournal_ReturnsFullSyncRequired_WhenCheckpointEqualsWatermark()
     {
         await using var factory = new TestWebApplicationFactory();
         using var client = factory.CreateClient();
@@ -126,11 +147,12 @@ public class JournalEndpointTests
         {
             var s = await db.Spaces.SingleAsync(s => s.Id == space.Id);
             s.JournalPrunedBefore = watermark;
+            var trackedMember = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            trackedMember.LastSyncAt = watermark;
             await db.SaveChangesAsync();
         });
 
-        // Query with since == watermark — boundary should require full sync
-        var response = await GetJournalAsync(client, space.Id, token, since: watermark);
+        var response = await GetJournalAsync(client, space.Id, token);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await ReadJsonAsync<JournalResponse>(response);
@@ -147,8 +169,14 @@ public class JournalEndpointTests
         var member = await factory.CreateMemberAsync(space.Id, "Zoe");
         var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
 
-        // No pruning has happened — JournalPrunedBefore is null
-        var response = await GetJournalAsync(client, space.Id, token, since: DateTime.UtcNow.AddMinutes(-5));
+        await factory.WithDbContextAsync(async db =>
+        {
+            var trackedMember = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            trackedMember.LastSyncAt = DateTime.UtcNow.AddMinutes(-5);
+            await db.SaveChangesAsync();
+        });
+
+        var response = await GetJournalAsync(client, space.Id, token);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await ReadJsonAsync<JournalResponse>(response);
@@ -156,7 +184,7 @@ public class JournalEndpointTests
     }
 
     [Fact]
-    public async Task GetJournal_UpdatesMemberLastSyncAt()
+    public async Task GetJournal_InitialCallEnablesJournalingWithoutAdvancingCheckpoint()
     {
         await using var factory = new TestWebApplicationFactory();
         using var client = factory.CreateClient();
@@ -172,16 +200,66 @@ public class JournalEndpointTests
             m.LastSyncAt.Should().BeNull();
         });
 
-        var beforeCall = DateTime.UtcNow;
         var response = await GetJournalAsync(client, space.Id, token);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadJsonAsync<JournalResponse>(response);
+        body.Checkpoint.Should().BeOnOrAfter(DateTime.UtcNow.AddMinutes(-1));
 
         await factory.WithDbContextAsync(async db =>
         {
             var m = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
             m.LastSyncAt.Should().NotBeNull();
-            m.LastSyncAt!.Value.Should().BeOnOrAfter(beforeCall);
+            m.LastSyncAt!.Value.Should().Be(DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc));
+        });
+    }
+
+    [Fact]
+    public async Task PostCheckpoint_UpdatesMemberLastSyncAt()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        var journalResponse = await ReadJsonAsync<JournalResponse>(await GetJournalAsync(client, space.Id, token));
+
+        var checkpointResponse = await PostCheckpointAsync(client, space.Id, token, journalResponse.Checkpoint);
+        checkpointResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var m = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            m.LastSyncAt.Should().Be(journalResponse.Checkpoint);
+        });
+    }
+
+    [Fact]
+    public async Task DeleteCheckpoint_ClearsMemberLastSyncAt()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var space = await factory.CreateSpaceAsync();
+        var member = await factory.CreateMemberAsync(space.Id, "Zoe");
+        var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var trackedMember = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            trackedMember.LastSyncAt = DateTime.UtcNow.AddMinutes(-5);
+            await db.SaveChangesAsync();
+        });
+
+        var response = await DeleteCheckpointAsync(client, space.Id, token);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await factory.WithDbContextAsync(async db =>
+        {
+            var m = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            m.LastSyncAt.Should().BeNull();
         });
     }
 
@@ -195,7 +273,14 @@ public class JournalEndpointTests
         var member = await factory.CreateMemberAsync(space.Id, "Zoe");
         var token = GenerateTestJwt(member.Id, space.Id, member.DisplayName);
 
-        var response = await GetJournalAsync(client, space.Id, token, since: DateTime.UtcNow);
+        await factory.WithDbContextAsync(async db =>
+        {
+            var trackedMember = await db.SpaceMembers.SingleAsync(m => m.Id == member.Id);
+            trackedMember.LastSyncAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+        });
+
+        var response = await GetJournalAsync(client, space.Id, token);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await ReadJsonAsync<JournalResponse>(response);
@@ -381,7 +466,7 @@ public class JournalEndpointTests
     }
 
     [Fact]
-    public async Task GetJournal_WithoutSinceParameter_ReturnsAllItems()
+    public async Task GetJournal_WithoutCheckpoint_ReturnsAllItems()
     {
         await using var factory = new TestWebApplicationFactory();
         using var client = factory.CreateClient();
@@ -404,7 +489,7 @@ public class JournalEndpointTests
             sharedAt: DateTime.UtcNow,
             fileSize: 0);
 
-        // No since parameter → should return everything
+        // No checkpoint yet -> should return everything
         var response = await GetJournalAsync(client, space.Id, token);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -417,15 +502,26 @@ public class JournalEndpointTests
     // --- Helpers ---
 
     private static async Task<HttpResponseMessage> GetJournalAsync(
-        HttpClient client, Guid spaceId, string? token = null, DateTimeOffset? since = null)
+        HttpClient client, Guid spaceId, string? token = null)
     {
-        var url = $"/v1/spaces/{spaceId}/journal";
-        if (since.HasValue)
-        {
-            url += $"?since={since.Value.UtcDateTime:O}";
-        }
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"/v1/spaces/{spaceId}/journal");
+        AddAuthorizationHeader(request, token);
+        return await client.SendAsync(request);
+    }
 
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+    private static async Task<HttpResponseMessage> PostCheckpointAsync(
+        HttpClient client, Guid spaceId, string token, DateTime checkpoint)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"/v1/spaces/{spaceId}/journal/checkpoint");
+        request.Content = JsonContent.Create(new { checkpoint });
+        AddAuthorizationHeader(request, token);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> DeleteCheckpointAsync(
+        HttpClient client, Guid spaceId, string token)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Delete, $"/v1/spaces/{spaceId}/journal/checkpoint");
         AddAuthorizationHeader(request, token);
         return await client.SendAsync(request);
     }
@@ -482,6 +578,7 @@ public class JournalEndpointTests
 
     private sealed record JournalResponse(
         bool FullSyncRequired,
+        DateTime Checkpoint,
         SpaceItemResponse[] AddedOrUpdated,
         Guid[] Deleted);
 


### PR DESCRIPTION
Adds a crash-safe journal synchronization API so offline clients can incrementally reconcile deletions without re-fetching the full space state every time.

## Changes

### Data model
- new `DeletedItem` tombstones (`ItemId`, `SpaceId`, `DeletedAt`)
- `Space.JournalPrunedBefore` watermark for journal retention gaps
- `SpaceMember.LastSyncAt` stores the member's last acknowledged checkpoint

### Journal API
- `GET /v1/spaces/{spaceId}/journal`
  - uses the stored member checkpoint
  - returns `{ fullSyncRequired, checkpoint, addedOrUpdated, deleted }`
- `POST /v1/spaces/{spaceId}/journal/checkpoint`
  - advances the member checkpoint after the client successfully applies the response
- `DELETE /v1/spaces/{spaceId}/journal/checkpoint`
  - clears the stored checkpoint and forces the next journal read to behave like a full sync

### Write path
- delete and move flows write tombstones in the same save operation as the item removal
- journal pruning is count-based per space via `Journal:MaxEntriesPerSpace` (default `1000` in `appsettings.json`)
- tombstones are only maintained for spaces with at least one enrolled journaling member

### Tests
- covers checkpoint replay-until-ack behavior, reset semantics, pruning, auth, full-sync boundaries, and delete/move integration
- current validation: `238` server tests and `54` CLI tests passing

Closes #155
Related to #132, #157
