### PR TITLE
feat(client): support pasting images from clipboard

### DIFF
--- a/src/SharedSpaces.Client/src/features/space-view/file-preview.ts
+++ b/src/SharedSpaces.Client/src/features/space-view/file-preview.ts
@@ -10,6 +10,7 @@ export type PreviewType = FilePreviewType;
 
 const IMAGE_EXTENSIONS = new Set([
   'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'ico',
+  'avif', 'heic', 'heif', 'tiff',
 ]);
 
 const VIDEO_EXTENSIONS = new Set(['mp4', 'webm']);

--- a/src/SharedSpaces.Client/src/features/space-view/space-view.test.ts
+++ b/src/SharedSpaces.Client/src/features/space-view/space-view.test.ts
@@ -1963,92 +1963,118 @@ describe('SpaceView - Delete Confirmation', () => {
       expect((element as any).dragOver).toBe(false);
     });
   });
+});
 
-  describe('Clipboard paste', () => {
-    function createPasteEvent(
-      items: Array<{ kind: string; type: string; file?: File | null }>,
-    ): { event: ClipboardEvent; preventDefault: ReturnType<typeof vi.fn> } {
-      const preventDefault = vi.fn();
+describe('SpaceView - Clipboard paste', () => {
+  const serverUrl = 'http://localhost:5000';
+  const spaceId = '550e8400-e29b-41d4-a716-446655440000';
+  const token = 'test-jwt-token';
 
-      return {
-        event: {
-          clipboardData: {
-            items: items.map((item) => ({
-              kind: item.kind,
-              type: item.type,
-              getAsFile: () => item.file ?? null,
-            })),
-          },
-          preventDefault,
-        } as unknown as ClipboardEvent,
+  let element: SpaceView;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  function createPasteEvent(
+    items: Array<{ kind: string; type: string; file?: File | null }>,
+  ): { event: ClipboardEvent; preventDefault: ReturnType<typeof vi.fn> } {
+    const preventDefault = vi.fn();
+
+    return {
+      event: {
+        clipboardData: {
+          items: items.map((item) => ({
+            kind: item.kind,
+            type: item.type,
+            getAsFile: () => item.file ?? null,
+          })),
+        },
         preventDefault,
-      };
+      } as unknown as ClipboardEvent,
+      preventDefault,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+    globalThis.fetch = mockFetch;
+
+    element = document.createElement('space-view') as SpaceView;
+    element.setAttribute('server-url', serverUrl);
+    element.setAttribute('space-id', spaceId);
+    (element as any).token = token;
+    (element as any).serverUrl = serverUrl;
+    (element as any).spaceId = spaceId;
+  });
+
+  afterEach(() => {
+    if (element.parentNode) {
+      element.parentNode.removeChild(element);
     }
+    vi.restoreAllMocks();
+  });
 
-    beforeEach(() => {
-      (element as any).serverUrl = serverUrl;
-      (element as any).spaceId = spaceId;
-      (element as any).token = token;
-    });
+  it('uploads pasted images through uploadFiles and generates fallback filenames', async () => {
+    const uploadFilesSpy = vi.spyOn(element as any, 'uploadFiles').mockResolvedValue(undefined);
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
 
-    it('uploads pasted images through uploadFiles and generates fallback filenames', async () => {
-      const uploadFilesSpy = vi.spyOn(element as any, 'uploadFiles').mockResolvedValue(undefined);
-      vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+    const unnamedImage = new File(['image-data'], '', { type: 'image/png' });
+    const { event, preventDefault } = createPasteEvent([
+      { kind: 'file', type: 'image/png', file: unnamedImage },
+    ]);
 
-      const unnamedImage = new File(['image-data'], '', { type: 'image/png' });
-      const { event, preventDefault } = createPasteEvent([
-        { kind: 'file', type: 'image/png', file: unnamedImage },
-      ]);
+    await (element as any).handleTextareaPaste(event);
 
-      await (element as any).handleTextareaPaste(event);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(uploadFilesSpy).toHaveBeenCalledOnce();
 
-      expect(preventDefault).toHaveBeenCalledOnce();
-      expect(uploadFilesSpy).toHaveBeenCalledOnce();
+    const uploadedFiles = uploadFilesSpy.mock.calls[0][0] as File[];
+    expect(uploadedFiles).toHaveLength(1);
+    expect(uploadedFiles[0].name).toBe('pasted-image-1700000000000-1.png');
+    expect(uploadedFiles[0].type).toBe('image/png');
+  });
 
-      const uploadedFiles = uploadFilesSpy.mock.calls[0][0] as File[];
-      expect(uploadedFiles).toHaveLength(1);
-      expect(uploadedFiles[0].name).toBe('pasted-image-1700000000000-1.png');
-      expect(uploadedFiles[0].type).toBe('image/png');
-    });
+  it('preserves named clipboard images and ignores non-image clipboard items', async () => {
+    const uploadFilesSpy = vi.spyOn(element as any, 'uploadFiles').mockResolvedValue(undefined);
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
 
-    it('preserves named clipboard images and ignores non-image clipboard items', async () => {
-      const uploadFilesSpy = vi.spyOn(element as any, 'uploadFiles').mockResolvedValue(undefined);
-      vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+    const namedImage = new File(['image-data'], 'clipboard-photo.jpg', { type: 'image/jpeg' });
+    const unnamedImage = new File(['image-data'], '', { type: 'image/png' });
+    const pdfFile = new File(['pdf-data'], 'notes.pdf', { type: 'application/pdf' });
+    const { event, preventDefault } = createPasteEvent([
+      { kind: 'string', type: 'text/plain' },
+      { kind: 'file', type: 'image/jpeg', file: namedImage },
+      { kind: 'file', type: 'application/pdf', file: pdfFile },
+      { kind: 'file', type: 'image/png', file: unnamedImage },
+    ]);
 
-      const namedImage = new File(['image-data'], 'clipboard-photo.jpg', { type: 'image/jpeg' });
-      const unnamedImage = new File(['image-data'], '', { type: 'image/png' });
-      const pdfFile = new File(['pdf-data'], 'notes.pdf', { type: 'application/pdf' });
-      const { event, preventDefault } = createPasteEvent([
-        { kind: 'string', type: 'text/plain' },
-        { kind: 'file', type: 'image/jpeg', file: namedImage },
-        { kind: 'file', type: 'application/pdf', file: pdfFile },
-        { kind: 'file', type: 'image/png', file: unnamedImage },
-      ]);
+    await (element as any).handleTextareaPaste(event);
 
-      await (element as any).handleTextareaPaste(event);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(uploadFilesSpy).toHaveBeenCalledOnce();
 
-      expect(preventDefault).toHaveBeenCalledOnce();
-      expect(uploadFilesSpy).toHaveBeenCalledOnce();
+    const uploadedFiles = uploadFilesSpy.mock.calls[0][0] as File[];
+    expect(uploadedFiles.map((file) => file.name)).toEqual([
+      'clipboard-photo.jpg',
+      'pasted-image-1700000000000-2.png',
+    ]);
+  });
 
-      const uploadedFiles = uploadFilesSpy.mock.calls[0][0] as File[];
-      expect(uploadedFiles.map((file) => file.name)).toEqual([
-        'clipboard-photo.jpg',
-        'pasted-image-1700000000000-2.png',
-      ]);
-    });
+  it('does not intercept regular text paste', async () => {
+    const uploadFilesSpy = vi.spyOn(element as any, 'uploadFiles').mockResolvedValue(undefined);
 
-    it('does not intercept regular text paste', async () => {
-      const uploadFilesSpy = vi.spyOn(element as any, 'uploadFiles').mockResolvedValue(undefined);
+    const { event, preventDefault } = createPasteEvent([
+      { kind: 'string', type: 'text/plain' },
+    ]);
 
-      const { event, preventDefault } = createPasteEvent([
-        { kind: 'string', type: 'text/plain' },
-      ]);
+    await (element as any).handleTextareaPaste(event);
 
-      await (element as any).handleTextareaPaste(event);
-
-      expect(preventDefault).not.toHaveBeenCalled();
-      expect(uploadFilesSpy).not.toHaveBeenCalled();
-    });
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(uploadFilesSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/SharedSpaces.Client/src/features/space-view/space-view.test.ts
+++ b/src/SharedSpaces.Client/src/features/space-view/space-view.test.ts
@@ -1963,6 +1963,93 @@ describe('SpaceView - Delete Confirmation', () => {
       expect((element as any).dragOver).toBe(false);
     });
   });
+
+  describe('Clipboard paste', () => {
+    function createPasteEvent(
+      items: Array<{ kind: string; type: string; file?: File | null }>,
+    ): { event: ClipboardEvent; preventDefault: ReturnType<typeof vi.fn> } {
+      const preventDefault = vi.fn();
+
+      return {
+        event: {
+          clipboardData: {
+            items: items.map((item) => ({
+              kind: item.kind,
+              type: item.type,
+              getAsFile: () => item.file ?? null,
+            })),
+          },
+          preventDefault,
+        } as unknown as ClipboardEvent,
+        preventDefault,
+      };
+    }
+
+    beforeEach(() => {
+      (element as any).serverUrl = serverUrl;
+      (element as any).spaceId = spaceId;
+      (element as any).token = token;
+    });
+
+    it('uploads pasted images through uploadFiles and generates fallback filenames', async () => {
+      const uploadFilesSpy = vi.spyOn(element as any, 'uploadFiles').mockResolvedValue(undefined);
+      vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
+      const unnamedImage = new File(['image-data'], '', { type: 'image/png' });
+      const { event, preventDefault } = createPasteEvent([
+        { kind: 'file', type: 'image/png', file: unnamedImage },
+      ]);
+
+      await (element as any).handleTextareaPaste(event);
+
+      expect(preventDefault).toHaveBeenCalledOnce();
+      expect(uploadFilesSpy).toHaveBeenCalledOnce();
+
+      const uploadedFiles = uploadFilesSpy.mock.calls[0][0] as File[];
+      expect(uploadedFiles).toHaveLength(1);
+      expect(uploadedFiles[0].name).toBe('pasted-image-1700000000000-1.png');
+      expect(uploadedFiles[0].type).toBe('image/png');
+    });
+
+    it('preserves named clipboard images and ignores non-image clipboard items', async () => {
+      const uploadFilesSpy = vi.spyOn(element as any, 'uploadFiles').mockResolvedValue(undefined);
+      vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
+      const namedImage = new File(['image-data'], 'clipboard-photo.jpg', { type: 'image/jpeg' });
+      const unnamedImage = new File(['image-data'], '', { type: 'image/png' });
+      const pdfFile = new File(['pdf-data'], 'notes.pdf', { type: 'application/pdf' });
+      const { event, preventDefault } = createPasteEvent([
+        { kind: 'string', type: 'text/plain' },
+        { kind: 'file', type: 'image/jpeg', file: namedImage },
+        { kind: 'file', type: 'application/pdf', file: pdfFile },
+        { kind: 'file', type: 'image/png', file: unnamedImage },
+      ]);
+
+      await (element as any).handleTextareaPaste(event);
+
+      expect(preventDefault).toHaveBeenCalledOnce();
+      expect(uploadFilesSpy).toHaveBeenCalledOnce();
+
+      const uploadedFiles = uploadFilesSpy.mock.calls[0][0] as File[];
+      expect(uploadedFiles.map((file) => file.name)).toEqual([
+        'clipboard-photo.jpg',
+        'pasted-image-1700000000000-2.png',
+      ]);
+    });
+
+    it('does not intercept regular text paste', async () => {
+      const uploadFilesSpy = vi.spyOn(element as any, 'uploadFiles').mockResolvedValue(undefined);
+
+      const { event, preventDefault } = createPasteEvent([
+        { kind: 'string', type: 'text/plain' },
+      ]);
+
+      await (element as any).handleTextareaPaste(event);
+
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(uploadFilesSpy).not.toHaveBeenCalled();
+    });
+  });
 });
 
 

--- a/src/SharedSpaces.Client/src/features/space-view/space-view.ts
+++ b/src/SharedSpaces.Client/src/features/space-view/space-view.ts
@@ -55,6 +55,58 @@ export interface JoinedSpace {
   token: string;
 }
 
+function hasFileExtension(fileName: string): boolean {
+  const lastDot = fileName.lastIndexOf('.');
+  return lastDot > 0 && lastDot < fileName.length - 1;
+}
+
+function getImageExtension(contentType: string): string {
+  switch (contentType.toLowerCase()) {
+    case 'image/jpeg':
+      return 'jpg';
+    case 'image/gif':
+      return 'gif';
+    case 'image/webp':
+      return 'webp';
+    case 'image/bmp':
+      return 'bmp';
+    case 'image/svg+xml':
+      return 'svg';
+    case 'image/avif':
+      return 'avif';
+    case 'image/heic':
+      return 'heic';
+    case 'image/heif':
+      return 'heif';
+    case 'image/tiff':
+    case 'image/tif':
+      return 'tiff';
+    case 'image/png':
+    default:
+      return 'png';
+  }
+}
+
+function normalizeClipboardImageFiles(files: File[]): File[] {
+  const timestamp = Date.now();
+
+  return files.map((file, index) => {
+    const trimmedName = file.name.trim();
+    if (trimmedName && hasFileExtension(trimmedName)) {
+      return file;
+    }
+
+    const extension = getImageExtension(file.type);
+    const baseName = trimmedName.replace(/^\.+|\.+$/g, '')
+      || `pasted-image-${timestamp}-${index + 1}`;
+
+    return new File([file], `${baseName}.${extension}`, {
+      type: file.type,
+      lastModified: file.lastModified,
+    });
+  });
+}
+
 @customElement('space-view')
 export class SpaceView extends BaseElement {
   @property({ type: String, attribute: 'api-base-url' })
@@ -655,6 +707,31 @@ export class SpaceView extends BaseElement {
       e.preventDefault();
       this.handleTextSubmit();
     }
+  };
+
+  private getClipboardImageFiles(event: ClipboardEvent): File[] {
+    const items = event.clipboardData?.items;
+    if (!items) return [];
+
+    return Array.from(items)
+      .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => file !== null);
+  }
+
+  private handleTextareaPaste = async (event: ClipboardEvent) => {
+    const imageFiles = this.getClipboardImageFiles(event);
+    if (
+      imageFiles.length === 0
+      || !this.serverUrl
+      || !this.spaceId
+      || !this.token
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    await this.uploadFiles(normalizeClipboardImageFiles(imageFiles));
   };
 
   private handleFileSelect = async (e: Event) => {
@@ -1441,6 +1518,7 @@ export class SpaceView extends BaseElement {
             .value=${this.textInput}
             @input=${this.handleTextInput}
             @keydown=${this.handleTextKeydown}
+            @paste=${this.handleTextareaPaste}
             ?disabled=${this.isUploading}
             class="w-full resize-none rounded-t-lg border-0 bg-transparent px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:outline-none disabled:opacity-50"
           ></textarea>


### PR DESCRIPTION
## Summary
Pasting a screenshot into the compose box currently does nothing, which makes quick sharing slower than drag and drop or file picker uploads. This change lets users paste clipboard images directly into the composer while reusing the existing upload flow so pasted files behave the same as any other shared file.

## What changed
- detect `image/*` clipboard file items on the compose textarea and hand them to `uploadFiles()`
- preserve clipboard-provided filenames when available and generate fallback names for unnamed pasted images
- leave non-image paste behavior untouched so normal text paste still works
- add regression tests for image-only paste, mixed clipboard contents, and text-only paste

## Notes
- compose-related Playwright screenshots were unchanged before vs after this change
- the screenshot suite still has pre-existing IndexedDB `VersionError` failures in the pending/offline cases of `screenshots.spec.ts`

## Testing
- `npx vitest run src/features/space-view/space-view.test.ts`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #179