### PR TITLE
fix(client): support share_target multi-file sharing

### DIFF
--- a/src/SharedSpaces.Client/public/manifest.json
+++ b/src/SharedSpaces.Client/public/manifest.json
@@ -70,8 +70,9 @@
       "url": "url",
       "files": [
         {
-          "name": "file",
+          "name": "files",
           "accept": [
+            "*/*",
             "image/*",
             "video/*",
             "audio/*",

--- a/src/SharedSpaces.Client/src/lib/idb-storage.test.ts
+++ b/src/SharedSpaces.Client/src/lib/idb-storage.test.ts
@@ -17,6 +17,7 @@ import {
   clearStoredTokens,
   syncStoredTokens,
   type OfflineQueueItem,
+  type PendingShareItem,
 } from './idb-storage';
 
 beforeEach(async () => {
@@ -24,6 +25,25 @@ beforeEach(async () => {
   await clearOfflineQueue();
   await clearStoredTokens();
 });
+
+async function seedPendingShares(items: PendingShareItem[]): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.open('shared-spaces-db', 2);
+
+    request.onsuccess = () => {
+      const db = request.result;
+      const tx = db.transaction('pending-shares', 'readwrite');
+      for (const item of items) {
+        tx.objectStore('pending-shares').put(item);
+      }
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error ?? new Error('Failed to seed pending shares'));
+    };
+
+    request.onerror = () => reject(request.error);
+  });
+}
 
 describe('idb-storage', () => {
   describe('pending shares', () => {
@@ -39,6 +59,20 @@ describe('idb-storage', () => {
     it('clearPendingShares removes all items', async () => {
       await clearPendingShares();
       expect(await getPendingShares()).toEqual([]);
+    });
+
+    it('returns pending shares newest-first with stable tie-breakers', async () => {
+      await seedPendingShares([
+        { id: '1000-0001-b', type: 'text', content: 'second', timestamp: 1000 },
+        { id: '2000-0000-c', type: 'text', content: 'latest', timestamp: 2000 },
+        { id: '1000-0000-a', type: 'text', content: 'first', timestamp: 1000 },
+      ]);
+
+      expect((await getPendingShares()).map((item) => item.id)).toEqual([
+        '2000-0000-c',
+        '1000-0000-a',
+        '1000-0001-b',
+      ]);
     });
   });
 

--- a/src/SharedSpaces.Client/src/lib/idb-storage.ts
+++ b/src/SharedSpaces.Client/src/lib/idb-storage.ts
@@ -61,7 +61,10 @@ function getDB(): Promise<IDBPDatabase> {
 
 export async function getPendingShares(): Promise<PendingShareItem[]> {
   const db = await getDB();
-  return db.getAll(PENDING_SHARES_STORE);
+  return (await db.getAll(PENDING_SHARES_STORE)).sort((a, b) =>
+    (b.timestamp - a.timestamp)
+    || a.id.localeCompare(b.id),
+  );
 }
 
 export async function removePendingShare(id: string): Promise<void> {

--- a/src/SharedSpaces.Client/src/sw.ts
+++ b/src/SharedSpaces.Client/src/sw.ts
@@ -43,8 +43,12 @@ class SyncUploadError extends Error {
   }
 }
 
+let dbInstance: Promise<IDBDatabase> | null = null;
+
 function openDB(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
+  if (dbInstance) return dbInstance;
+
+  dbInstance = new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
     request.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result;
@@ -59,21 +63,39 @@ function openDB(): Promise<IDBDatabase> {
       }
     };
     request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error);
+    request.onerror = () => {
+      dbInstance = null;
+      reject(request.error);
+    };
   });
+
+  return dbInstance;
+}
+
+function createPendingShareId(timestamp: number, index = 0): string {
+  return `${timestamp}-${index.toString().padStart(4, '0')}-${crypto.randomUUID()}`;
+}
+
+async function storePendingShares(items: Record<string, unknown>[]) {
+  if (items.length === 0) return;
+
+  const db = await openDB();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(PENDING_SHARES_STORE, 'readwrite');
+    const store = tx.objectStore(PENDING_SHARES_STORE);
+    for (const item of items) {
+      store.put(item);
+    }
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error ?? new Error('Failed to store pending shares'));
+  });
+
+  void notifyClients({ type: 'pending-share-added' });
 }
 
 async function storePendingShare(item: Record<string, unknown>) {
-  const db = await openDB();
-  return new Promise<void>((resolve, reject) => {
-    const tx = db.transaction(PENDING_SHARES_STORE, 'readwrite');
-    tx.objectStore(PENDING_SHARES_STORE).put(item);
-    tx.oncomplete = () => {
-      resolve();
-      void notifyClients({ type: 'pending-share-added' });
-    };
-    tx.onerror = () => reject(tx.error);
-  });
+  await storePendingShares([item]);
 }
 
 async function notifyClients(message: unknown) {
@@ -258,26 +280,26 @@ async function handleShareTarget(request: Request): Promise<Response> {
 
     if (files.length > 0) {
       const timestamp = Date.now();
+      const pendingShares = await Promise.all(files.map(async (file, index) => ({
+        id: createPendingShareId(timestamp, index),
+        type: 'file' as const,
+        fileName: file.name,
+        fileType: file.type,
+        fileData: await file.arrayBuffer(),
+        fileSize: file.size,
+        timestamp,
+      })));
 
-      for (const file of files) {
-        await storePendingShare({
-          id: crypto.randomUUID(),
-          type: 'file',
-          fileName: file.name,
-          fileType: file.type,
-          fileData: await file.arrayBuffer(),
-          fileSize: file.size,
-          timestamp,
-        });
-      }
+      await storePendingShares(pendingShares);
     } else {
       const content = [title, text, url].filter(Boolean).join('\n');
       if (content) {
+        const timestamp = Date.now();
         await storePendingShare({
-          id: crypto.randomUUID(),
+          id: createPendingShareId(timestamp),
           type: 'text',
           content,
-          timestamp: Date.now(),
+          timestamp,
         });
       }
     }

--- a/src/SharedSpaces.Client/src/sw.ts
+++ b/src/SharedSpaces.Client/src/sw.ts
@@ -247,29 +247,37 @@ async function handleShareTarget(request: Request): Promise<Response> {
     const title = formData.get('title') || '';
     const text = formData.get('text') || '';
     const url = formData.get('url') || '';
-    const file = formData.get('file');
-    const id = crypto.randomUUID();
-    const timestamp = Date.now();
+    const files = formData
+      .getAll('files')
+      .filter((entry): entry is File => entry instanceof File && entry.size > 0);
 
-    if (file && file instanceof File && file.size > 0) {
-      const arrayBuffer = await file.arrayBuffer();
-      await storePendingShare({
-        id,
-        type: 'file',
-        fileName: file.name,
-        fileType: file.type,
-        fileData: arrayBuffer,
-        fileSize: file.size,
-        timestamp,
-      });
+    const legacyFile = formData.get('file');
+    if (files.length === 0 && legacyFile instanceof File && legacyFile.size > 0) {
+      files.push(legacyFile);
+    }
+
+    if (files.length > 0) {
+      const timestamp = Date.now();
+
+      for (const file of files) {
+        await storePendingShare({
+          id: crypto.randomUUID(),
+          type: 'file',
+          fileName: file.name,
+          fileType: file.type,
+          fileData: await file.arrayBuffer(),
+          fileSize: file.size,
+          timestamp,
+        });
+      }
     } else {
       const content = [title, text, url].filter(Boolean).join('\n');
       if (content) {
         await storePendingShare({
-          id,
+          id: crypto.randomUUID(),
           type: 'text',
           content,
-          timestamp,
+          timestamp: Date.now(),
         });
       }
     }


### PR DESCRIPTION
Windows Explorer only surfaced SharedSpaces as a share target when a single file was selected. This updates the PWA share-target handling so the app stays eligible for multi-file shares and receives every shared file instead of just the first one.

## What changed
- register the share target using the multi-file form field name (`files`)
- broaden the accepted type match so Windows can keep the app in the share sheet for mixed file selections
- update the service worker to queue all shared files while preserving the existing single-file/text fallback path

## Notes
- Existing installs may need a refresh or reinstall before Windows picks up the updated manifest registration.