### PR TITLE
feat(cli): add passive synchronization mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The `sync` command keeps a local folder in sync with a space:
 - **Real-time updates** — Receives new files and deletions via SignalR (WebSocket)
 - **Local file watching** — Automatically uploads new files added to the folder
 - **Fallback polling** — Falls back to HTTP polling if the WebSocket connection drops
+- **Passive mode** — Pass `--passive` (with optional `--interval <seconds>`, default `300`) to skip SignalR and pull the journal on a fixed interval instead. Local uploads still happen immediately.
 - **Resilience** — Automatic reconnection with exponential backoff, atomic file writes, deduplication to prevent upload loops
 
 Press `Ctrl+C` to stop syncing gracefully.

--- a/src/SharedSpaces.Cli.Core/Services/SyncService.cs
+++ b/src/SharedSpaces.Cli.Core/Services/SyncService.cs
@@ -82,7 +82,7 @@ public sealed class SyncService : IAsyncDisposable
             if (PassiveInterval <= TimeSpan.Zero)
                 throw new InvalidOperationException("PassiveInterval must be positive.");
 
-            Console.WriteLine($"[Passive] Mode enabled — polling journal every {PassiveInterval.TotalSeconds:0}s. SignalR is disabled.");
+            Console.WriteLine($"[Passive] Mode enabled — polling journal every {PassiveInterval.TotalSeconds:0.###}s. SignalR is disabled.");
         }
 
         ScanExistingFiles();

--- a/src/SharedSpaces.Cli.Core/Services/SyncService.cs
+++ b/src/SharedSpaces.Cli.Core/Services/SyncService.cs
@@ -20,11 +20,26 @@ public sealed class SyncService : IAsyncDisposable
     private DateTime _lastDisconnect = DateTime.MinValue;
     private PeriodicTimer? _pollingTimer;
     private Task? _pollingTask;
+    private PeriodicTimer? _passiveTimer;
+    private Task? _passiveTask;
     private CancellationTokenSource? _validationDelayCts;
     private Task _validationTask = Task.CompletedTask;
     private readonly object _validationLock = new();
 
     internal TimeSpan JournalValidationDelay { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// When true, the service skips the SignalR hub and instead pulls the journal on a
+    /// fixed interval (see <see cref="PassiveInterval"/>). The local file watcher still
+    /// uploads outbound changes immediately.
+    /// </summary>
+    public bool Passive { get; set; }
+
+    /// <summary>
+    /// Interval between journal pulls when <see cref="Passive"/> is enabled.
+    /// Defaults to 5 minutes. Must be positive.
+    /// </summary>
+    public TimeSpan PassiveInterval { get; set; } = TimeSpan.FromMinutes(5);
 
     public SyncService(
         SharedSpacesApiClient apiClient,
@@ -62,10 +77,27 @@ public sealed class SyncService : IAsyncDisposable
         Console.WriteLine($"Starting sync for space {_spaceId}...");
         Console.WriteLine($"Local folder: {_localFolder}");
 
+        if (Passive)
+        {
+            if (PassiveInterval <= TimeSpan.Zero)
+                throw new InvalidOperationException("PassiveInterval must be positive.");
+
+            Console.WriteLine($"[Passive] Mode enabled — polling journal every {PassiveInterval.TotalSeconds:0}s. SignalR is disabled.");
+        }
+
         ScanExistingFiles();
         await InitialSyncAsync(ct);
-        await ConnectSignalRAsync(ct);
-        StartFileWatcher(ct);
+
+        if (Passive)
+        {
+            StartFileWatcher(ct);
+            StartPassivePolling(ct);
+        }
+        else
+        {
+            await ConnectSignalRAsync(ct);
+            StartFileWatcher(ct);
+        }
 
         try
         {
@@ -283,6 +315,45 @@ public sealed class SyncService : IAsyncDisposable
         Console.WriteLine("[Polling] Stopping HTTP polling.");
         _pollingTimer?.Dispose();
         _pollingTimer = null;
+    }
+
+    private void StartPassivePolling(CancellationToken ct)
+    {
+        if (_passiveTimer != null)
+            return;
+
+        var timer = new PeriodicTimer(PassiveInterval);
+        _passiveTimer = timer;
+        _passiveTask = PassivePollLoopAsync(timer, ct);
+    }
+
+    private async Task PassivePollLoopAsync(PeriodicTimer timer, CancellationToken ct)
+    {
+        try
+        {
+            while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+            {
+                Console.WriteLine("[Passive] Polling journal for changes...");
+
+                try
+                {
+                    var journal = await _apiClient.GetJournalAsync(_serverUrl, _spaceId, _jwtToken, ct);
+                    await ApplyRemoteChangesAsync(journal, ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"[Passive] Poll failed: {ex.Message}");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal cancellation
+        }
     }
 
     internal void ScheduleJournalValidation(CancellationToken ct)
@@ -692,6 +763,8 @@ public sealed class SyncService : IAsyncDisposable
     {
         _watcher?.Dispose();
         StopPolling();
+        _passiveTimer?.Dispose();
+        _passiveTimer = null;
         lock (_validationLock)
         {
             try { _validationDelayCts?.Cancel(); } catch (ObjectDisposedException) { }
@@ -700,6 +773,10 @@ public sealed class SyncService : IAsyncDisposable
         if (_pollingTask != null)
         {
             try { await _pollingTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
+        }
+        if (_passiveTask != null)
+        {
+            try { await _passiveTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
         }
         if (_hubConnection != null)
         {

--- a/src/SharedSpaces.Cli/Commands/SyncCommand.cs
+++ b/src/SharedSpaces.Cli/Commands/SyncCommand.cs
@@ -11,23 +11,44 @@ public static class SyncCommand
     {
         var spaceIdOption = new Option<string>("--space-id") { Description = "ID of the space to sync from", Required = true };
         var folderOption = new Option<string>("--folder") { Description = "Path to local folder for synced files", Required = true };
+        var passiveOption = new Option<bool>("--passive") { Description = "Use periodic journal polling instead of real-time SignalR updates" };
+        var intervalOption = new Option<int>("--interval") { Description = "Passive poll interval in seconds (requires --passive). Default: 300, minimum: 5", DefaultValueFactory = _ => 300 };
 
         var command = new Command("sync", "Sync files from a space to a local folder");
         command.Add(spaceIdOption);
         command.Add(folderOption);
+        command.Add(passiveOption);
+        command.Add(intervalOption);
 
         command.SetAction(async (parseResult, ct) =>
         {
             var spaceId = parseResult.GetRequiredValue(spaceIdOption);
             var folder = parseResult.GetRequiredValue(folderOption);
-            await HandleAsync(spaceId, folder, ct);
+            var passive = parseResult.GetValue(passiveOption);
+            var interval = parseResult.GetValue(intervalOption);
+            var intervalExplicit = parseResult.GetResult(intervalOption) is { Implicit: false };
+            await HandleAsync(spaceId, folder, passive, interval, intervalExplicit, ct);
         });
 
         return command;
     }
 
-    private static async Task HandleAsync(string spaceId, string folder, CancellationToken ct)
+    private static async Task HandleAsync(string spaceId, string folder, bool passive, int intervalSeconds, bool intervalExplicit, CancellationToken ct)
     {
+        if (intervalExplicit && !passive)
+        {
+            Console.Error.WriteLine("Error: --interval can only be used together with --passive.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        if (passive && intervalSeconds < 5)
+        {
+            Console.Error.WriteLine("Error: --interval must be at least 5 seconds.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
         var configService = new ConfigService();
         SpaceEntry? space;
 
@@ -73,7 +94,11 @@ public static class SyncCommand
             space.ServerUrl,
             space.SpaceId,
             space.JwtToken,
-            folder);
+            folder)
+        {
+            Passive = passive,
+            PassiveInterval = TimeSpan.FromSeconds(intervalSeconds),
+        };
 
         try
         {

--- a/src/SharedSpaces.Cli/README.md
+++ b/src/SharedSpaces.Cli/README.md
@@ -69,6 +69,24 @@ The sync engine:
 
 Press `Ctrl+C` to stop syncing.
 
+#### Passive mode
+
+For use cases that don't need real-time updates (e.g., periodic snapshots, low-bandwidth or offline-mostly scenarios), pass `--passive` to skip the SignalR hub and pull the journal on a fixed interval instead:
+
+```bash
+# Default: pull journal every 5 minutes
+sharedspaces sync --space-id <guid> --folder ~/shared --passive
+
+# Custom interval (seconds, minimum 5)
+sharedspaces sync --space-id <guid> --folder ~/shared --passive --interval 60
+```
+
+In passive mode:
+- **No SignalR connection** is opened.
+- The journal is fetched once at startup and again on every tick at `--interval` seconds (default `300`).
+- Local file uploads still happen immediately via the file watcher — only inbound changes are delayed.
+- `--interval` is only valid together with `--passive`.
+
 ## Config
 
 Tokens are stored in `~/.sharedspaces/config.json`. Each entry contains only the JWT — all metadata (space ID, server URL, display name) is extracted from the token's claims at runtime.

--- a/tests/SharedSpaces.Cli.Core.Tests/SyncServiceTests.cs
+++ b/tests/SharedSpaces.Cli.Core.Tests/SyncServiceTests.cs
@@ -1097,6 +1097,64 @@ public class SyncServiceTests : IDisposable
             .Count(r => r.Method == HttpMethod.Get && r.Url.EndsWith($"/v1/spaces/{spaceId}/journal"));
         journalRequests.Should().Be(1, "only one journal validation should fire after debounce settles");
     }
+
+    [Fact]
+    public async Task PassiveMode_PollsJournalOnInterval()
+    {
+        var spaceId = Guid.NewGuid();
+        var serverUrl = "https://server.example.com";
+        var jwt = "fake-jwt-token";
+
+        MockJournal(spaceId, serverUrl);
+
+        using var apiClient = new SharedSpacesApiClient(_httpClient);
+        await using var service = new SyncService(apiClient, serverUrl, spaceId.ToString(), jwt, _tempDir)
+        {
+            Passive = true,
+            PassiveInterval = TimeSpan.FromMilliseconds(150),
+        };
+
+        using var cts = new CancellationTokenSource();
+        var runTask = service.RunAsync(cts.Token);
+
+        // Wait long enough for the initial sync + at least 2 passive ticks
+        await Task.Delay(500);
+        cts.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+
+        var journalGets = _mockHttp.GetRequests()
+            .Count(r => r.Method == HttpMethod.Get && r.Url.EndsWith($"/v1/spaces/{spaceId}/journal"));
+        journalGets.Should().BeGreaterOrEqualTo(3,
+            "passive mode should fetch the journal once for initial sync and again on each tick");
+    }
+
+    [Fact]
+    public async Task PassiveMode_DoesNotOpenSignalRHub()
+    {
+        var spaceId = Guid.NewGuid();
+        var serverUrl = "https://server.example.com";
+        var jwt = "fake-jwt-token";
+
+        MockJournal(spaceId, serverUrl);
+
+        using var apiClient = new SharedSpacesApiClient(_httpClient);
+        await using var service = new SyncService(apiClient, serverUrl, spaceId.ToString(), jwt, _tempDir)
+        {
+            Passive = true,
+            PassiveInterval = TimeSpan.FromMilliseconds(200),
+        };
+
+        using var cts = new CancellationTokenSource();
+        var runTask = service.RunAsync(cts.Token);
+
+        await Task.Delay(300);
+        cts.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+
+        var hubRequests = _mockHttp.GetRequests()
+            .Count(r => r.Url.Contains($"/v1/spaces/{spaceId}/hub", StringComparison.OrdinalIgnoreCase));
+        hubRequests.Should().Be(0, "passive mode must not negotiate or open the SignalR hub");
+    }
 }
 
 public class MockHttpMessageHandler : HttpMessageHandler

--- a/tests/SharedSpaces.Cli.Core.Tests/SyncServiceTests.cs
+++ b/tests/SharedSpaces.Cli.Core.Tests/SyncServiceTests.cs
@@ -1117,8 +1117,17 @@ public class SyncServiceTests : IDisposable
         using var cts = new CancellationTokenSource();
         var runTask = service.RunAsync(cts.Token);
 
-        // Wait long enough for the initial sync + at least 2 passive ticks
-        await Task.Delay(500);
+        // Poll until we observe the expected number of journal GETs (initial sync + 2 passive ticks),
+        // capping at a generous timeout to avoid timing-sensitive flakiness.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            var count = _mockHttp.GetRequests()
+                .Count(r => r.Method == HttpMethod.Get && r.Url.EndsWith($"/v1/spaces/{spaceId}/journal"));
+            if (count >= 3) break;
+            await Task.Delay(25);
+        }
+
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
 


### PR DESCRIPTION
Some sync use cases (periodic snapshots, low-bandwidth or mostly-offline workflows) don't need real-time updates. Holding a SignalR hub open is overkill — the journal API with checkpoints already supports cheap incremental catch-up, so we now expose that as a passive mode.

## Approach

Adds `--passive` and `--interval` flags to `sharedspaces sync`. When `--passive` is set:

- No SignalR hub is opened.
- The journal is fetched once at startup, then again on a fixed `PeriodicTimer` (default `300` s, minimum `5` s).
- Each tick reuses the existing `ApplyRemoteChangesAsync` / checkpoint flow — no server changes.
- The local `FileSystemWatcher` still uploads outbound changes immediately, so only inbound is delayed (hybrid by design).

`--interval` without `--passive` is rejected, and intervals below 5 s are rejected.

## Notes for reviewers

- `SyncService` gains two public setters (`Passive`, `PassiveInterval`) rather than ctor params, to keep the existing 5-arg ctor and all current tests intact.
- `RunAsync` now branches: active path is unchanged; passive path is `InitialSync` -> `StartFileWatcher` -> `StartPassivePolling`. The 5 s polling fallback used during SignalR disconnects is intentionally not reused — the passive timer always fires.
- Added two unit tests: one asserts the journal is polled on the configured interval, the other asserts no SignalR negotiate/hub requests are made in passive mode. All 61 tests pass.
- No UI changes, so no Playwright work.

Fixes: #183