### PR TITLE
docs(cli): integrate passive sync flags into command reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ sharedspaces sync --space-id 550e8400-e29b-41d4-a716-446655440000 --folder ~/sha
 | `join <url>` | Exchange an invitation PIN for an access token and store it locally |
 | `spaces` | List all joined spaces (supports `--json` for machine-readable output) |
 | `upload <file>` | Upload a file to a space (`--space-id` required) |
-| `sync` | Two-way real-time file sync between a space and a local folder (`--space-id`, `--folder` required) |
+| `sync` | Two-way file sync between a space and a local folder (`--space-id`, `--folder` required; `--passive` for periodic polling instead of real-time SignalR) |
 
 ### How sync works
 

--- a/src/SharedSpaces.Cli/README.md
+++ b/src/SharedSpaces.Cli/README.md
@@ -52,15 +52,22 @@ sharedspaces spaces --json
 
 ### `sharedspaces sync`
 
-Sync files from a space to a local folder. Downloads existing files, then watches for changes in both directions in real-time.
+Sync files from a space to a local folder. By default, downloads existing files and then watches for changes in both directions in real-time. A [passive mode](#passive-mode) is also available for periodic, low-bandwidth syncing.
 
 ```bash
 sharedspaces sync --space-id 550e8400-e29b-41d4-a716-446655440000 --folder ~/shared
 ```
 
-Both `--space-id` and `--folder` are required. The folder is created if it doesn't exist.
+Options:
 
-The sync engine:
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--space-id <guid>` | yes | ID of the space to sync from |
+| `--folder <path>` | yes | Local folder for synced files (created if missing) |
+| `--passive` | no | Skip the SignalR hub and poll the journal on a fixed interval. See [Passive mode](#passive-mode). |
+| `--interval <seconds>` | no | Passive poll interval. Default `300`, minimum `5`. Only valid with `--passive`. |
+
+The default (active) sync engine:
 - **Downloads** all existing files on startup
 - **Streams** new files and deletions in real-time via SignalR
 - **Uploads** new files added to the local folder automatically


### PR DESCRIPTION
Follow-up to #184. The passive-mode PR added a dedicated subsection but left the sync command's opening blurb and option list unchanged, so `--passive` and `--interval` weren't surfaced where users look first (the command intro and the options listing).

## Changes

- `src/SharedSpaces.Cli/README.md`: replace the "Both `--space-id` and `--folder` are required" prose with a proper options table that includes `--passive` and `--interval`, link the new flag to the existing Passive mode subsection, and reframe the sync engine bullet list as the default (active) mode.
- `README.md`: note `--passive` in the sync row of the commands table so it's visible from the top-level overview.

No code or behavior changes — docs only.