### PR TITLE
fix(client): align + button size with space pills

### DIFF
--- a/src/SharedSpaces.Client/src/app-shell.ts
+++ b/src/SharedSpaces.Client/src/app-shell.ts
@@ -503,7 +503,7 @@ export class AppShell extends BaseElement {
               })}
               <button
                 @click=${() => { this.view = 'join'; }}
-                class="${this.pillBase} ${this.view === 'join' ? this.pillActive : this.pillDefault}"
+                class="rounded-full border px-1.5 py-1.5 text-xs font-medium transition aspect-square inline-flex items-center justify-center ${this.view === 'join' ? this.pillActive : this.pillDefault}"
                 aria-label="Join a space"
               >
                 +


### PR DESCRIPTION
The "+" (join space) button in the desktop pill bar was visually larger than the adjacent space pills, breaking the horizontal rhythm of the nav.

Replaced the shared `pillBase` padding (`px-3`) with `px-1.5` plus `aspect-square` so the button renders as a circle whose diameter matches the pill height.