### PR TITLE
feat(client): add manual PWA update check via version label

### DIFF
--- a/src/SharedSpaces.Client/src/app-shell.ts
+++ b/src/SharedSpaces.Client/src/app-shell.ts
@@ -43,6 +43,7 @@ import {
   type PendingShareItem,
 } from './lib/idb-storage';
 import { decodeShareLinkSegment } from './lib/share-link';
+import { initSwUpdate, checkForUpdates, activateUpdate } from './lib/sw-update';
 
 interface SpaceEntry {
   serverUrl: string;
@@ -75,6 +76,7 @@ export class AppShell extends BaseElement {
   @state() private spaceConnectionStates: Record<string, ConnectionState> = {};
   @state() private pendingShareCount = 0;
   @state() private pendingShares: PendingShareItem[] = [];
+  @state() private swUpdateAvailable = false;
   @state() private sheetOpen = false;
   @state() private spaceSettingsOpen = false;
   @state() private sharedToken?: string;
@@ -132,8 +134,13 @@ export class AppShell extends BaseElement {
       }
     });
 
-    // Listen for SW messages (registration handled by vite-plugin-pwa)
+    // Listen for SW messages (registration handled by sw-update service)
     navigator.serviceWorker?.addEventListener('message', this.handleSwMessage);
+
+    // Initialise SW update detection
+    initSwUpdate({
+      onUpdateAvailable: () => { this.swUpdateAvailable = true; },
+    });
 
 
     // Check pending shares from IndexedDB
@@ -218,6 +225,14 @@ export class AppShell extends BaseElement {
   private handleSwMessage = (event: MessageEvent) => {
     if (event.data?.type === 'pending-share-added') {
       this.refreshPendingShareCount();
+    }
+  };
+
+  private handleVersionClick = () => {
+    if (this.swUpdateAvailable) {
+      activateUpdate();
+    } else {
+      checkForUpdates();
     }
   };
 
@@ -442,7 +457,12 @@ export class AppShell extends BaseElement {
                 SharedSpaces
               </button>
               <div class="flex items-center gap-3">
-                <span class="text-xs text-slate-500">v${__APP_VERSION__}</span>
+                <button
+                  type="button"
+                  class="text-xs bg-transparent border-none p-0 cursor-pointer ${this.swUpdateAvailable ? 'version-rainbow font-semibold' : 'text-slate-500'}"
+                  title="${this.swUpdateAvailable ? 'Update available — click to activate' : 'Check for updates'}"
+                  @click=${this.handleVersionClick}
+                >v${__APP_VERSION__}</button>
                 <button
                   @click=${() => { this.view = 'admin'; }}
                   class="sm:hidden ${this.pillBase} ${this.view === 'admin' ? this.pillActive : this.pillDefault}"

--- a/src/SharedSpaces.Client/src/app-shell.ts
+++ b/src/SharedSpaces.Client/src/app-shell.ts
@@ -138,7 +138,7 @@ export class AppShell extends BaseElement {
     navigator.serviceWorker?.addEventListener('message', this.handleSwMessage);
 
     // Initialise SW update detection
-    initSwUpdate({
+    void initSwUpdate({
       onUpdateAvailable: () => { this.swUpdateAvailable = true; },
     });
 
@@ -232,7 +232,7 @@ export class AppShell extends BaseElement {
     if (this.swUpdateAvailable) {
       activateUpdate();
     } else {
-      checkForUpdates();
+      void checkForUpdates();
     }
   };
 

--- a/src/SharedSpaces.Client/src/index.css
+++ b/src/SharedSpaces.Client/src/index.css
@@ -71,3 +71,19 @@ select {
 .bottom-sheet-open {
   transform: translateY(0);
 }
+
+/* Rainbow text animation for SW update available */
+@keyframes rainbow {
+  0%   { color: #f87171; }
+  15%  { color: #fb923c; }
+  30%  { color: #facc15; }
+  45%  { color: #4ade80; }
+  60%  { color: #38bdf8; }
+  75%  { color: #a78bfa; }
+  90%  { color: #f472b6; }
+  100% { color: #f87171; }
+}
+
+.version-rainbow {
+  animation: rainbow 3s linear infinite;
+}

--- a/src/SharedSpaces.Client/src/lib/sw-update.ts
+++ b/src/SharedSpaces.Client/src/lib/sw-update.ts
@@ -1,7 +1,7 @@
 /**
  * Lightweight service worker update manager.
  *
- * - Registers the SW (production only — dev mode is handled by vite-plugin-pwa)
+ * - Registers the SW (in both dev and production modes)
  * - Detects when a new SW is waiting to activate
  * - Exposes `checkForUpdates()` and `activateUpdate()`
  */
@@ -12,6 +12,7 @@ export interface SwUpdateCallbacks {
 
 let registration: ServiceWorkerRegistration | undefined;
 let callbacks: SwUpdateCallbacks | undefined;
+let refreshing = false;
 
 function trackInstalling(worker: ServiceWorker) {
   worker.addEventListener('statechange', () => {
@@ -52,8 +53,10 @@ export async function initSwUpdate(cb: SwUpdateCallbacks): Promise<void> {
     }
   });
 
-  // Reload when the new SW takes over
+  // Reload when the new SW takes over (one-shot guard to prevent loops)
   navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (refreshing) return;
+    refreshing = true;
     window.location.reload();
   });
 }

--- a/src/SharedSpaces.Client/src/lib/sw-update.ts
+++ b/src/SharedSpaces.Client/src/lib/sw-update.ts
@@ -1,0 +1,75 @@
+/**
+ * Lightweight service worker update manager.
+ *
+ * - Registers the SW (production only — dev mode is handled by vite-plugin-pwa)
+ * - Detects when a new SW is waiting to activate
+ * - Exposes `checkForUpdates()` and `activateUpdate()`
+ */
+
+export interface SwUpdateCallbacks {
+  onUpdateAvailable: () => void;
+}
+
+let registration: ServiceWorkerRegistration | undefined;
+let callbacks: SwUpdateCallbacks | undefined;
+
+function trackInstalling(worker: ServiceWorker) {
+  worker.addEventListener('statechange', () => {
+    if (worker.state === 'installed' && navigator.serviceWorker.controller) {
+      // New SW installed while an existing one controls the page → update available
+      callbacks?.onUpdateAvailable();
+    }
+  });
+}
+
+/**
+ * Initialise the update manager. Call once from the app shell.
+ * Returns immediately in environments without service worker support.
+ */
+export async function initSwUpdate(cb: SwUpdateCallbacks): Promise<void> {
+  if (!('serviceWorker' in navigator)) return;
+  callbacks = cb;
+
+  try {
+    registration = await navigator.serviceWorker.register(
+      import.meta.env.DEV ? '/dev-sw.js?dev-sw' : '/sw.js',
+      { type: import.meta.env.DEV ? 'module' : 'classic' },
+    );
+  } catch {
+    // Registration may fail in unsupported contexts (e.g. non-HTTPS without localhost)
+    return;
+  }
+
+  // A worker may already be waiting (e.g. page was left open during a deploy)
+  if (registration.waiting) {
+    callbacks.onUpdateAvailable();
+  }
+
+  registration.addEventListener('updatefound', () => {
+    const installing = registration!.installing;
+    if (installing) {
+      trackInstalling(installing);
+    }
+  });
+
+  // Reload when the new SW takes over
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    window.location.reload();
+  });
+}
+
+/**
+ * Ask the browser to re-fetch the SW script and check for a new version.
+ */
+export async function checkForUpdates(): Promise<void> {
+  if (registration) {
+    await registration.update();
+  }
+}
+
+/**
+ * Tell the waiting SW to activate, which triggers `controllerchange` → reload.
+ */
+export function activateUpdate(): void {
+  registration?.waiting?.postMessage({ type: 'SKIP_WAITING' });
+}

--- a/src/SharedSpaces.Client/src/sw.ts
+++ b/src/SharedSpaces.Client/src/sw.ts
@@ -379,9 +379,16 @@ self.addEventListener('sync' as keyof ServiceWorkerGlobalScopeEventMap, ((event:
 // --- Lifecycle ---
 
 self.addEventListener('install', () => {
-  self.skipWaiting();
+  // Don't call skipWaiting() automatically — let the client decide
+  // when to activate the new worker via a SKIP_WAITING message.
 });
 
 self.addEventListener('activate', (event: ExtendableEvent) => {
   event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', (event: ExtendableMessageEvent) => {
+  if (event.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
 });

--- a/src/SharedSpaces.Client/vite.config.ts
+++ b/src/SharedSpaces.Client/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
       strategies: 'injectManifest',
       srcDir: 'src',
       filename: 'sw.ts',
-      injectRegister: 'auto',
+      injectRegister: false,
       manifest: false,
       devOptions: {
         enabled: true,


### PR DESCRIPTION
Previously the service worker called `skipWaiting()` unconditionally on install, so updates activated silently without user awareness. This change gives users visibility into pending updates and control over when they activate.

## Approach

The version label in the header (`v1.x.x`) now doubles as the update UI:

- **Update available** -- the label shows a rainbow text animation and clicking it activates the waiting service worker (page reloads).
- **No update pending** -- clicking the label manually checks for a new SW version via `registration.update()`.

Key pieces:

1. **SW lifecycle change** -- Removed auto `skipWaiting()` from the install listener. The SW now only calls `skipWaiting()` when it receives a `{ type: 'SKIP_WAITING' }` message from the client.
2. **`sw-update.ts` service** -- New lightweight module that registers the SW, detects waiting workers via `updatefound`/`statechange`, and exposes `checkForUpdates()` and `activateUpdate()` helpers.
3. **App-shell wiring** -- Version label becomes a button with reactive state; rainbow CSS animation applied when `swUpdateAvailable` is true.
4. **`injectRegister: false`** in vite config so vite-plugin-pwa does not inject its own registration logic.

## Notes

- The rainbow effect only appears once the new SW has fully installed and is waiting -- not during download.
- On first visit (no prior SW), the new worker still claims clients immediately via the `activate` handler (`clients.claim()`), so initial install UX is unchanged.