### PR TITLE
feat(client): show OS-specific modifier key instead of Ctrl/⌘

### DIFF
--- a/src/SharedSpaces.Client/src/features/space-view/space-view.ts
+++ b/src/SharedSpaces.Client/src/features/space-view/space-view.ts
@@ -5,6 +5,7 @@ import { BaseElement } from '../../lib/base-element';
 import type { AppViewChangeDetail } from '../../lib/navigation';
 import { getToken, removeToken } from '../../lib/token-storage';
 import { formatRelativeTime } from '../../lib/format-time';
+import { modifierKey } from '../../lib/platform';
 import {
   SignalRClient,
   type ConnectionState,
@@ -2031,7 +2032,7 @@ export class SpaceView extends BaseElement {
             </div>
 
             <div class="flex items-center gap-2">
-              <span class="hidden text-xs text-slate-500 sm:inline">Ctrl/⌘+Enter</span>
+              <span class="hidden text-xs text-slate-500 sm:inline">${modifierKey}+Enter</span>
               <button
                 @click=${this.handleTextSubmit}
                 ?disabled=${this.isUploading || !this.textInput.trim()}

--- a/src/SharedSpaces.Client/src/lib/platform.test.ts
+++ b/src/SharedSpaces.Client/src/lib/platform.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('platform', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it.each(['MacIntel', 'MacPPC', 'iPhone', 'iPad', 'iPod'])(
+    'returns ⌘ on %s',
+    async (platform) => {
+      vi.stubGlobal('navigator', { platform });
+      const { modifierKey } = await import('./platform');
+      expect(modifierKey).toBe('⌘');
+    }
+  );
+
+  it.each(['Win32', 'Linux x86_64', 'Linux armv7l'])(
+    'returns Ctrl on %s',
+    async (platform) => {
+      vi.stubGlobal('navigator', { platform });
+      const { modifierKey } = await import('./platform');
+      expect(modifierKey).toBe('Ctrl');
+    }
+  );
+
+  it('returns Ctrl when navigator is undefined', async () => {
+    vi.stubGlobal('navigator', undefined);
+    const { modifierKey } = await import('./platform');
+    expect(modifierKey).toBe('Ctrl');
+  });
+});

--- a/src/SharedSpaces.Client/src/lib/platform.ts
+++ b/src/SharedSpaces.Client/src/lib/platform.ts
@@ -1,0 +1,5 @@
+const isMac =
+  typeof navigator !== 'undefined' &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+
+export const modifierKey = isMac ? '⌘' : 'Ctrl';


### PR DESCRIPTION
The keyboard shortcut hint next to the Send button showed "Ctrl/⌘+Enter" regardless of the user's platform, which felt generic and slightly cluttered.

This adds a small `platform.ts` utility that detects macOS via `navigator.platform` and exports a `modifierKey` constant. The hint now renders the actual modifier for the current OS -- `⌘+Enter` on Mac, `Ctrl+Enter` everywhere else.