### PR TITLE
fix(client): wrap join view inputs in form for Enter key submit

### DIFF
--- a/src/SharedSpaces.Client/src/features/join/join-view.test.ts
+++ b/src/SharedSpaces.Client/src/features/join/join-view.test.ts
@@ -379,6 +379,51 @@ describe('join-view', () => {
     });
   });
 
+  describe('form submission', () => {
+    it('submits when Enter is pressed in an input', async () => {
+      await element.updateComplete;
+
+      mockExchangeToken.mockResolvedValue({ token: 'jwt-token' });
+
+      (element as any).serverUrl = 'http://example.com';
+      (element as any).pin = '123456';
+      (element as any).displayName = 'Alice';
+      await element.updateComplete;
+
+      const form = element.querySelector('form')!;
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+      // Wait for async handleJoin to complete
+      await element.updateComplete;
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(mockExchangeToken).toHaveBeenCalledWith(
+        'http://example.com',
+        '123456',
+        'Alice'
+      );
+    });
+
+    it('prevents default form submission (no page reload)', async () => {
+      await element.updateComplete;
+
+      const form = element.querySelector('form')!;
+      const event = new Event('submit', { bubbles: true, cancelable: true });
+      form.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('renders a form element wrapping the inputs', async () => {
+      await element.updateComplete;
+
+      const form = element.querySelector('form');
+      expect(form).toBeTruthy();
+      expect(form!.querySelector('#invitation')).toBeTruthy();
+      expect(form!.querySelector('#displayName')).toBeTruthy();
+    });
+  });
+
   describe('render', () => {
     it('renders invitation input in paste mode', async () => {
       await element.updateComplete;

--- a/src/SharedSpaces.Client/src/features/join/join-view.test.ts
+++ b/src/SharedSpaces.Client/src/features/join/join-view.test.ts
@@ -393,15 +393,13 @@ describe('join-view', () => {
       const form = element.querySelector('form')!;
       form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
 
-      // Wait for async handleJoin to complete
-      await element.updateComplete;
-      await new Promise((r) => setTimeout(r, 0));
-
-      expect(mockExchangeToken).toHaveBeenCalledWith(
-        'http://example.com',
-        '123456',
-        'Alice'
-      );
+      await vi.waitFor(() => {
+        expect(mockExchangeToken).toHaveBeenCalledWith(
+          'http://example.com',
+          '123456',
+          'Alice'
+        );
+      });
     });
 
     it('prevents default form submission (no page reload)', async () => {

--- a/src/SharedSpaces.Client/src/features/join/join-view.ts
+++ b/src/SharedSpaces.Client/src/features/join/join-view.ts
@@ -97,6 +97,11 @@ export class JoinView extends BaseElement {
     this.errorMessage = '';
   };
 
+  private handleSubmit = (e: Event) => {
+    e.preventDefault();
+    this.handleJoin();
+  };
+
   private handleJoin = async () => {
     this.errorMessage = '';
 
@@ -158,7 +163,7 @@ export class JoinView extends BaseElement {
 
   override render() {
     return html`
-      <div class="max-w-lg space-y-8">
+      <form class="max-w-lg space-y-8" @submit=${this.handleSubmit}>
         <div>
           <h2 class="text-2xl font-semibold tracking-tight text-white">
             Join a Space
@@ -175,6 +180,7 @@ export class JoinView extends BaseElement {
               Invitation
             </p>
             <button
+              type="button"
               @click=${this.toggleEntryMode}
               class="text-xs text-sky-400 hover:text-sky-300 transition"
               ?disabled=${this.isLoading}
@@ -258,13 +264,13 @@ export class JoinView extends BaseElement {
 
         <!-- Join Button -->
         <button
-          @click=${this.handleJoin}
+          type="submit"
           ?disabled=${this.isLoading}
           class="w-full rounded-full bg-sky-400 px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-sky-300 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           ${this.isLoading ? 'Joining...' : 'Join Space'}
         </button>
-      </div>
+      </form>
     `;
   }
 }

--- a/src/SharedSpaces.Client/src/features/join/join-view.ts
+++ b/src/SharedSpaces.Client/src/features/join/join-view.ts
@@ -99,6 +99,7 @@ export class JoinView extends BaseElement {
 
   private handleSubmit = (e: Event) => {
     e.preventDefault();
+    if (this.isLoading) return;
     this.handleJoin();
   };
 


### PR DESCRIPTION
Pressing Enter in the "Join a Space" view textboxes did nothing because the inputs were standalone elements inside a `<div>`, not wrapped in a `<form>`. The browser needs a form context to trigger submission on Enter.

**Approach:**

- Replaced the outer `<div>` with a `<form>` element with a `@submit` handler that calls `preventDefault()` and delegates to the existing `handleJoin` logic
- Changed the "Join Space" button to `type="submit"` so it acts as the form's submit target
- Marked the entry-mode toggle button as `type="button"` to prevent it from accidentally triggering form submission

**Tests added:**

- Form submit triggers the join flow (simulating Enter key behavior)
- `preventDefault()` is called on submit (no page reload)
- Form element wraps all inputs correctly