### PR TITLE
docs(client,server): update README with architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ Anonymous by design: users pick a display name when joining a space. No email, n
 
 ## Screenshots
 
-**Home view** — Your spaces across multiple servers:
-
-![SharedSpaces home view](docs/screenshots/home--desktop.png)
-
 **Inside a space** — Real-time shared content:
 
 ![SharedSpaces space view with content](docs/screenshots/space--desktop.png)
@@ -186,6 +182,35 @@ SharedSpaces/
 ```
 
 ## Architecture
+
+```mermaid
+graph LR
+    subgraph "Static Host (single deployment)"
+        Client[Web Client<br/>SPA]
+    end
+
+    subgraph "Server A"
+        API_A[API + SignalR]
+        DB_A[(SQLite)]
+        FS_A[File Storage]
+        API_A --- DB_A
+        API_A --- FS_A
+    end
+
+    subgraph "Server B"
+        API_B[API + SignalR]
+        DB_B[(SQLite)]
+        FS_B[File Storage]
+        API_B --- DB_B
+        API_B --- FS_B
+    end
+
+    Client -- "JWT + REST/WS" --> API_A
+    Client -- "JWT + REST/WS" --> API_B
+
+    CLI[CLI Tool] -- "JWT + REST/WS" --> API_A
+    CLI -- "JWT + REST/WS" --> API_B
+```
 
 The server and client are **fully decoupled**. The server is a pure API with no UI. The client is a standalone SPA that connects to any server via its base URL. A single client instance can connect to multiple servers simultaneously, each with its own JWT token for authentication.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,37 @@ Anonymous by design: users pick a display name when joining a space. No email, n
 
 ![SharedSpaces space view with content](docs/screenshots/space--desktop.png)
 
+## Deployment
+
+```mermaid
+graph LR
+    subgraph "Static Host (single deployment)"
+        Client[Web Client<br/>SPA]
+    end
+
+    subgraph "Server A"
+        API_A[API + SignalR]
+        DB_A[(SQLite)]
+        FS_A[File Storage]
+        API_A --- DB_A
+        API_A --- FS_A
+    end
+
+    subgraph "Server B"
+        API_B[API + SignalR]
+        DB_B[(SQLite)]
+        FS_B[File Storage]
+        API_B --- DB_B
+        API_B --- FS_B
+    end
+
+    Client -- "JWT + REST/WS" --> API_A
+    Client -- "JWT + REST/WS" --> API_B
+
+    CLI[CLI Tool] -- "JWT + REST/WS" --> API_A
+    CLI -- "JWT + REST/WS" --> API_B
+```
+
 ## Tech Stack
 
 - **Server:** .NET 10 (ASP.NET Core Web API)
@@ -182,35 +213,6 @@ SharedSpaces/
 ```
 
 ## Architecture
-
-```mermaid
-graph LR
-    subgraph "Static Host (single deployment)"
-        Client[Web Client<br/>SPA]
-    end
-
-    subgraph "Server A"
-        API_A[API + SignalR]
-        DB_A[(SQLite)]
-        FS_A[File Storage]
-        API_A --- DB_A
-        API_A --- FS_A
-    end
-
-    subgraph "Server B"
-        API_B[API + SignalR]
-        DB_B[(SQLite)]
-        FS_B[File Storage]
-        API_B --- DB_B
-        API_B --- FS_B
-    end
-
-    Client -- "JWT + REST/WS" --> API_A
-    Client -- "JWT + REST/WS" --> API_B
-
-    CLI[CLI Tool] -- "JWT + REST/WS" --> API_A
-    CLI -- "JWT + REST/WS" --> API_B
-```
 
 The server and client are **fully decoupled**. The server is a pure API with no UI. The client is a standalone SPA that connects to any server via its base URL. A single client instance can connect to multiple servers simultaneously, each with its own JWT token for authentication.
 


### PR DESCRIPTION
The README screenshots section had two images but the home view was redundant -- the space view better showcases the product. This also adds a visual explanation of the deployment architecture that was previously only described in prose.

**Changes:**

- Removed the home view screenshot, keeping only the "inside a space" screenshot
- Added a mermaid diagram to the Architecture section illustrating how one static-hosted client (and CLI) connects to multiple independent, self-contained servers