### PR TITLE
feat(cli): add `items` command to list space items

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ sharedspaces spaces
 sharedspaces spaces --json   # machine-readable output
 ```
 
+**List items in a space:**
+```bash
+sharedspaces items --space-id 550e8400-e29b-41d4-a716-446655440000
+sharedspaces items --space-id 550e8400-e29b-41d4-a716-446655440000 --json
+```
+
 **Upload a file:**
 ```bash
 sharedspaces upload myfile.txt --space-id 550e8400-e29b-41d4-a716-446655440000
@@ -144,6 +150,7 @@ sharedspaces sync --space-id 550e8400-e29b-41d4-a716-446655440000 --folder ~/sha
 |---------|-------------|
 | `join <url>` | Exchange an invitation PIN for an access token and store it locally |
 | `spaces` | List all joined spaces (supports `--json` for machine-readable output) |
+| `items` | List all items in a space (`--space-id` required; supports `--json`) |
 | `upload <file>` | Upload a file to a space (`--space-id` required) |
 | `sync` | Two-way file sync between a space and a local folder (`--space-id`, `--folder` required; `--passive` for periodic polling instead of real-time SignalR) |
 
@@ -200,7 +207,7 @@ SharedSpaces/
 │   │       ├── lib/                  # SignalR client, API client, utilities
 │   │       └── index.ts
 │   ├── SharedSpaces.Cli/             # .NET global tool (CLI entry point)
-│   │   └── Commands/                 # join, spaces, upload, sync
+│   │   └── Commands/                 # join, spaces, items, upload, sync
 │   └── SharedSpaces.Cli.Core/        # Shared CLI library
 │       ├── Services/                 # API client, config, sync engine
 │       └── Models/                   # Config model, JWT-backed space entry

--- a/src/SharedSpaces.Cli/Commands/ItemsCommand.cs
+++ b/src/SharedSpaces.Cli/Commands/ItemsCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.Text.Json;
+using SharedSpaces.Cli.Core.Models;
 using SharedSpaces.Cli.Core.Services;
 
 namespace SharedSpaces.Cli.Commands;
@@ -17,7 +18,7 @@ public static class ItemsCommand
 
         command.SetAction(async (parseResult, ct) =>
         {
-            var spaceId = parseResult.GetValue(spaceIdOption)!;
+            var spaceId = parseResult.GetRequiredValue(spaceIdOption);
             var json = parseResult.GetValue(jsonOption);
             await HandleAsync(spaceId, json, ct);
         });
@@ -28,19 +29,46 @@ public static class ItemsCommand
     private static async Task HandleAsync(string spaceId, bool json, CancellationToken ct)
     {
         var configService = new ConfigService();
-        var config = await configService.LoadAsync(ct);
+        SpaceEntry? space;
 
-        var space = config.Spaces.FirstOrDefault(s =>
-            s.SpaceId.Equals(spaceId, StringComparison.OrdinalIgnoreCase));
+        try
+        {
+            space = await configService.GetSpaceAsync(spaceId, ct);
+        }
+        catch (JsonException ex)
+        {
+            Console.Error.WriteLine($"Error: Failed to read CLI config — {ex.Message}");
+            Environment.ExitCode = 1;
+            return;
+        }
 
         if (space is null)
         {
-            Console.Error.WriteLine($"Space '{spaceId}' not found in config. Use 'spaces' to list joined spaces.");
+            Console.Error.WriteLine($"Error: No token found for space {spaceId}.");
+            Console.Error.WriteLine("Run 'sharedspaces join' first to join the space.");
+            Environment.ExitCode = 1;
             return;
         }
 
         using var client = new SharedSpacesApiClient();
-        var items = await client.ListItemsAsync(space.ServerUrl, space.SpaceId, space.JwtToken, ct);
+        List<SpaceItemResponse> items;
+
+        try
+        {
+            items = await client.ListItemsAsync(space.ServerUrl, space.SpaceId, space.JwtToken, ct);
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            Environment.ExitCode = 1;
+            return;
+        }
+        catch (JsonException ex)
+        {
+            Console.Error.WriteLine($"Error: Failed to parse server response — {ex.Message}");
+            Environment.ExitCode = 1;
+            return;
+        }
 
         if (json)
         {

--- a/src/SharedSpaces.Cli/Commands/ItemsCommand.cs
+++ b/src/SharedSpaces.Cli/Commands/ItemsCommand.cs
@@ -1,0 +1,84 @@
+using System.CommandLine;
+using System.Text.Json;
+using SharedSpaces.Cli.Core.Services;
+
+namespace SharedSpaces.Cli.Commands;
+
+public static class ItemsCommand
+{
+    public static Command Create()
+    {
+        var spaceIdArgument = new Argument<string>("space-id") { Description = "The ID of the space to list items from" };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var command = new Command("items", "List all items in a space");
+        command.Add(spaceIdArgument);
+        command.Add(jsonOption);
+
+        command.SetAction(async (parseResult, ct) =>
+        {
+            var spaceId = parseResult.GetValue(spaceIdArgument)!;
+            var json = parseResult.GetValue(jsonOption);
+            await HandleAsync(spaceId, json, ct);
+        });
+
+        return command;
+    }
+
+    private static async Task HandleAsync(string spaceId, bool json, CancellationToken ct)
+    {
+        var configService = new ConfigService();
+        var config = await configService.LoadAsync(ct);
+
+        var space = config.Spaces.FirstOrDefault(s =>
+            s.SpaceId.Equals(spaceId, StringComparison.OrdinalIgnoreCase));
+
+        if (space is null)
+        {
+            Console.Error.WriteLine($"Space '{spaceId}' not found in config. Use 'spaces' to list joined spaces.");
+            return;
+        }
+
+        using var client = new SharedSpacesApiClient();
+        var items = await client.ListItemsAsync(space.ServerUrl, space.SpaceId, space.JwtToken, ct);
+
+        if (json)
+        {
+            var output = items.Select(i => new
+            {
+                id = i.Id,
+                spaceId = i.SpaceId,
+                memberId = i.MemberId,
+                contentType = i.ContentType,
+                content = i.Content,
+                fileSize = i.FileSize,
+                sharedAt = i.SharedAt,
+            });
+            Console.WriteLine(JsonSerializer.Serialize(output, new JsonSerializerOptions { WriteIndented = true }));
+            return;
+        }
+
+        if (items.Count == 0)
+        {
+            Console.WriteLine("No items in this space.");
+            return;
+        }
+
+        const int idWidth = -36;
+        const int typeWidth = -12;
+        const int contentWidth = -30;
+        const int sizeWidth = -10;
+
+        Console.WriteLine(
+            $"{"ID",idWidth}  {"Type",typeWidth}  {"Content",contentWidth}  {"Size",sizeWidth}  Shared At");
+        Console.WriteLine(
+            $"{new string('-', -idWidth)}  {new string('-', -typeWidth)}  {new string('-', -contentWidth)}  {new string('-', -sizeWidth)}  {new string('-', 19)}");
+
+        foreach (var item in items)
+        {
+            var content = item.Content.Length > 30 ? item.Content[..27] + "..." : item.Content;
+            Console.WriteLine(
+                $"{item.Id.ToString(),idWidth}  {item.ContentType,typeWidth}  {content,contentWidth}  {item.FileSize.ToString(),sizeWidth}  {item.SharedAt:yyyy-MM-dd HH:mm:ss}");
+        }
+    }
+}

--- a/src/SharedSpaces.Cli/Commands/ItemsCommand.cs
+++ b/src/SharedSpaces.Cli/Commands/ItemsCommand.cs
@@ -8,16 +8,16 @@ public static class ItemsCommand
 {
     public static Command Create()
     {
-        var spaceIdArgument = new Argument<string>("space-id") { Description = "The ID of the space to list items from" };
+        var spaceIdOption = new Option<string>("--space-id") { Description = "The ID of the space to list items from", Required = true };
         var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
 
         var command = new Command("items", "List all items in a space");
-        command.Add(spaceIdArgument);
+        command.Add(spaceIdOption);
         command.Add(jsonOption);
 
         command.SetAction(async (parseResult, ct) =>
         {
-            var spaceId = parseResult.GetValue(spaceIdArgument)!;
+            var spaceId = parseResult.GetValue(spaceIdOption)!;
             var json = parseResult.GetValue(jsonOption);
             await HandleAsync(spaceId, json, ct);
         });

--- a/src/SharedSpaces.Cli/Program.cs
+++ b/src/SharedSpaces.Cli/Program.cs
@@ -4,6 +4,7 @@ using SharedSpaces.Cli.Commands;
 var rootCommand = new RootCommand("SharedSpaces CLI — join spaces and sync files");
 rootCommand.Add(JoinCommand.Create());
 rootCommand.Add(SpacesCommand.Create());
+rootCommand.Add(ItemsCommand.Create());
 rootCommand.Add(UploadCommand.Create());
 rootCommand.Add(SyncCommand.Create());
 

--- a/src/SharedSpaces.Cli/README.md
+++ b/src/SharedSpaces.Cli/README.md
@@ -50,6 +50,18 @@ sharedspaces spaces
 sharedspaces spaces --json
 ```
 
+### `sharedspaces items`
+
+List all items in a space.
+
+```bash
+# Formatted table output
+sharedspaces items --space-id 550e8400-e29b-41d4-a716-446655440000
+
+# Machine-readable JSON output
+sharedspaces items --space-id 550e8400-e29b-41d4-a716-446655440000 --json
+```
+
 ### `sharedspaces sync`
 
 Sync files from a space to a local folder. By default, downloads existing files and then watches for changes in both directions in real-time. A [passive mode](#passive-mode) is also available for periodic, low-bandwidth syncing.
@@ -61,13 +73,14 @@ sharedspaces sync --space-id 550e8400-e29b-41d4-a716-446655440000 --folder ~/sha
 Options:
 
 | Option | Required | Description |
-|--------|----------|-------------|
+| --- | --- | --- |
 | `--space-id <guid>` | yes | ID of the space to sync from |
 | `--folder <path>` | yes | Local folder for synced files (created if missing) |
 | `--passive` | no | Skip the SignalR hub and poll the journal on a fixed interval. See [Passive mode](#passive-mode). |
 | `--interval <seconds>` | no | Passive poll interval. Default `300`, minimum `5`. Only valid with `--passive`. |
 
 The default (active) sync engine:
+
 - **Downloads** all existing files on startup
 - **Streams** new files and deletions in real-time via SignalR
 - **Uploads** new files added to the local folder automatically
@@ -89,6 +102,7 @@ sharedspaces sync --space-id <guid> --folder ~/shared --passive --interval 60
 ```
 
 In passive mode:
+
 - **No SignalR connection** is opened.
 - The journal is fetched once at startup and again on every tick at `--interval` seconds (default `300`).
 - Local file uploads still happen immediately via the file watcher — only inbound changes are delayed.


### PR DESCRIPTION
The CLI had no way to inspect what items exist in a space without syncing the entire folder. This adds an `items` command that fetches and displays all items from the server, useful for scripting and quick inspection.

Relates to #133

## Approach

New `ItemsCommand` follows the same pattern as `SpacesCommand` -- looks up the space in local config by `--space-id`, calls the existing `SharedSpacesApiClient.ListItemsAsync`, and renders results as either a formatted table or `--json` output.

Usage:
```bash
sharedspaces items --space-id <guid>
sharedspaces items --space-id <guid> --json
```

## Changes

- `src/SharedSpaces.Cli/Commands/ItemsCommand.cs` -- new command implementation
- `src/SharedSpaces.Cli/Program.cs` -- register the command
- `src/SharedSpaces.Cli/README.md` and root `README.md` -- documentation