### PR TITLE
chore(server,cli): update vulnerable and outdated package references

### DIFF
--- a/src/AppHost.cs
+++ b/src/AppHost.cs
@@ -1,4 +1,4 @@
-#:sdk Aspire.AppHost.Sdk@13.0.2
+#:sdk Aspire.AppHost.Sdk@13.4.6
 #:project .\SharedSpaces.Server\SharedSpaces.Server.csproj
 #:package Aspire.Hosting.NodeJs@9.5.2
 

--- a/src/SharedSpaces.Cli.Core/SharedSpaces.Cli.Core.csproj
+++ b/src/SharedSpaces.Cli.Core/SharedSpaces.Cli.Core.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.21.0" />
   </ItemGroup>
 
 </Project>

--- a/src/SharedSpaces.Cli/Program.cs
+++ b/src/SharedSpaces.Cli/Program.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using SharedSpaces.Cli.Commands;
 
 var rootCommand = new RootCommand("SharedSpaces CLI — join spaces and sync files");
@@ -8,5 +9,4 @@ rootCommand.Add(ItemsCommand.Create());
 rootCommand.Add(UploadCommand.Create());
 rootCommand.Add(SyncCommand.Create());
 
-var config = new CommandLineConfiguration(rootCommand);
-return await config.InvokeAsync(args);
+return await CommandLineParser.Parse(rootCommand, args).InvokeAsync();

--- a/src/SharedSpaces.Cli/SharedSpaces.Cli.csproj
+++ b/src/SharedSpaces.Cli/SharedSpaces.Cli.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharedSpaces.Server/SharedSpaces.Server.csproj
+++ b/src/SharedSpaces.Server/SharedSpaces.Server.csproj
@@ -21,15 +21,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
-    <PackageReference Include="QRCoder" Version="1.7.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.21.0" />
+    <PackageReference Include="QRCoder" Version="1.8.0" />
   </ItemGroup>
 
 </Project>

--- a/src/SharedSpaces.Server/SharedSpaces.Server.csproj
+++ b/src/SharedSpaces.Server/SharedSpaces.Server.csproj
@@ -27,6 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
     <PackageReference Include="QRCoder" Version="1.7.0" />
   </ItemGroup>

--- a/tests/SharedSpaces.Cli.Core.Tests/SharedSpaces.Cli.Core.Tests.csproj
+++ b/tests/SharedSpaces.Cli.Core.Tests/SharedSpaces.Cli.Core.Tests.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" PrivateAssets="all" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SharedSpaces.Cli.Core.Tests/SyncServiceTests.cs
+++ b/tests/SharedSpaces.Cli.Core.Tests/SyncServiceTests.cs
@@ -1031,7 +1031,7 @@ public class SyncServiceTests : IDisposable
         var localPath = Path.Combine(_tempDir, "timestamped.txt");
         var localFile = new FileInfo(localPath);
         localFile.Exists.Should().BeTrue();
-        Math.Abs((localFile.LastWriteTimeUtc - sharedAt).TotalSeconds).Should().BeLessOrEqualTo(2,
+        Math.Abs((localFile.LastWriteTimeUtc - sharedAt).TotalSeconds).Should().BeLessThanOrEqualTo(2,
             "downloaded file should have LastWriteTimeUtc set to SharedAt from server");
     }
 
@@ -1133,7 +1133,7 @@ public class SyncServiceTests : IDisposable
 
         var journalGets = _mockHttp.GetRequests()
             .Count(r => r.Method == HttpMethod.Get && r.Url.EndsWith($"/v1/spaces/{spaceId}/journal"));
-        journalGets.Should().BeGreaterOrEqualTo(3,
+        journalGets.Should().BeGreaterThanOrEqualTo(3,
             "passive mode should fetch the journal once for initial sync and again on each tick");
     }
 

--- a/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
+++ b/tests/SharedSpaces.Server.Tests/JournalEndpointTests.cs
@@ -619,7 +619,7 @@ public class JournalEndpointTests
         await factory.WithDbContextAsync(async db =>
         {
             var deletedCount = await db.DeletedItems.CountAsync(d => d.SpaceId == space.Id);
-            deletedCount.Should().BeLessOrEqualTo(5);
+            deletedCount.Should().BeLessThanOrEqualTo(5);
 
             var s = await db.Spaces.SingleAsync(s => s.Id == space.Id);
             s.JournalPrunedBefore.Should().NotBeNull();

--- a/tests/SharedSpaces.Server.Tests/SharedSpaces.Server.Tests.csproj
+++ b/tests/SharedSpaces.Server.Tests/SharedSpaces.Server.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" PrivateAssets="all" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Two transitive vulnerabilities were flagged by NuGet security auditing (NU1902/NU1903), and a broader pass found numerous stale direct references across the solution.

## Security fixes

- `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 → 2.1.12 — fixes CVE-2025-6965 (GHSA-2m69-gcr7-jv3q, high severity): memory corruption in SQLite < 3.50.2. Pinned as an explicit reference in `SharedSpaces.Server.csproj` to override the vulnerable transitive version pulled by EF Core.

## Package updates

**Aspire**
- `Aspire.AppHost.Sdk` 13.0.2 → 13.4.6

**Server**
- `Microsoft.AspNetCore.Authentication.JwtBearer` 10.0.0 → 10.0.10
- `Microsoft.EntityFrameworkCore.Design` / `Sqlite` 10.0.0 → 10.0.10
- `Microsoft.IdentityModel.JsonWebTokens` 8.16.0 → 8.21.0
- `QRCoder` 1.7.0 → 1.8.0

**CLI / CLI.Core**
- `Microsoft.AspNetCore.SignalR.Client` 10.0.5 → 10.0.10
- `System.IdentityModel.Tokens.Jwt` 8.17.0 → 8.21.0
- `System.CommandLine` 2.0.0-beta5.25306.1 → 2.0.10 (stable)

**Tests (both test projects)**
- `coverlet.collector` 6.0.2 → 10.0.1
- `FluentAssertions` 6.12.0 → 8.10.0
- `Microsoft.NET.Test.Sdk` 17.12.0 → 18.8.1
- `xunit` 2.9.2 → 2.9.3
- `xunit.runner.visualstudio` 2.8.2 → 3.1.5
- `Microsoft.AspNetCore.Mvc.Testing` / `SignalR.Client` / `EntityFrameworkCore.InMemory` 10.0.0 → 10.0.10

## Breaking change adaptations

- **`System.CommandLine` 2.0 stable**: `CommandLineConfiguration` was removed. Replaced with `CommandLineParser.Parse(rootCommand, args).InvokeAsync()` (`System.CommandLine.Parsing` namespace).
- **`FluentAssertions` 8**: `BeLessOrEqualTo` / `BeGreaterOrEqualTo` were renamed to `BeLessThanOrEqualTo` / `BeGreaterThanOrEqualTo`. Updated 3 call sites across the two test projects.

All 311 tests pass after the updates.