### PR TITLE
ci(client): add comment-triggered screenshot regeneration workflow

### DIFF
--- a/.github/workflows/screenshots-regenerate.yml
+++ b/.github/workflows/screenshots-regenerate.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 concurrency:

--- a/.github/workflows/screenshots-regenerate.yml
+++ b/.github/workflows/screenshots-regenerate.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: write
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   group: regenerate-screenshots-${{ github.event.issue.number }}
@@ -25,15 +25,30 @@ jobs:
       run:
         working-directory: src/SharedSpaces.Client
     steps:
+      - name: Check PR source
+        id: pr
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          head_repo="$(gh api "/repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}" --jq '.head.repo.full_name')"
+          echo "head_repo=$head_repo" >> "$GITHUB_OUTPUT"
+          if [ "$head_repo" != "${{ github.repository }}" ]; then
+            echo "Skipping screenshot regeneration for fork PR: $head_repo"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.pr.outputs.head_repo == github.repository
 
       - name: Checkout PR branch
+        if: steps.pr.outputs.head_repo == github.repository
         working-directory: .
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh pr checkout ${{ github.event.issue.number }}
 
       - name: React to comment
+        if: steps.pr.outputs.head_repo == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -42,11 +57,13 @@ jobs:
             -f content='rocket'
 
       - name: Set up .NET 10
+        if: steps.pr.outputs.head_repo == github.repository
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
 
       - name: Set up Node.js
+        if: steps.pr.outputs.head_repo == github.repository
         uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -54,15 +71,19 @@ jobs:
           cache-dependency-path: src/SharedSpaces.Client/package-lock.json
 
       - name: Install dependencies
+        if: steps.pr.outputs.head_repo == github.repository
         run: npm ci
 
       - name: Install Playwright browsers
+        if: steps.pr.outputs.head_repo == github.repository
         run: npx playwright install --with-deps chromium
 
       - name: Run screenshot tests
+        if: steps.pr.outputs.head_repo == github.repository
         run: npx playwright test --project=screenshots
 
       - name: Commit and push updated screenshots
+        if: steps.pr.outputs.head_repo == github.repository
         working-directory: .
         run: |
           if [ -n "$(git status --porcelain docs/screenshots/)" ]; then
@@ -74,3 +95,8 @@ jobs:
           else
             echo "Screenshots are already up to date."
           fi
+
+      - name: Skip fork PR
+        if: steps.pr.outputs.head_repo != github.repository
+        working-directory: .
+        run: echo "Skipping screenshot regeneration for pull requests from forks."

--- a/.github/workflows/screenshots-regenerate.yml
+++ b/.github/workflows/screenshots-regenerate.yml
@@ -1,0 +1,75 @@
+name: Regenerate Screenshots
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: regenerate-screenshots-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  regenerate:
+    name: Regenerate screenshots
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.author_association == 'OWNER' &&
+      github.event.comment.body == '/regenerate-screenshots'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/SharedSpaces.Client
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout PR branch
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr checkout ${{ github.event.issue.number }}
+
+      - name: React to comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api -X POST \
+            "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='rocket'
+
+      - name: Set up .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: src/SharedSpaces.Client/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run screenshot tests
+        run: npx playwright test --project=screenshots
+
+      - name: Commit and push updated screenshots
+        working-directory: .
+        run: |
+          if [ -n "$(git status --porcelain docs/screenshots/)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add docs/screenshots/
+            git commit -m "chore(client): regenerate screenshots"
+            git push
+          else
+            echo "Screenshots are already up to date."
+          fi


### PR DESCRIPTION
Adds a workflow that regenerates screenshots when a repo owner comments `/regenerate-screenshots` on a PR. The workflow:

- Checks out the PR branch
- Runs Playwright screenshot tests
- Commits and pushes any updated screenshots back to the PR

This needs to be on `main` before it can be triggered, so it's split from the verification workflow PR (#199).

Security:
- Only triggers for comments from repo OWNER
- Uses exact string match (not substring)
- Concurrency group prevents parallel race conditions
