### PR TITLE
fix(ci): grant pull-requests write permission for PR comment reactions

### DIFF
--- a/.github/workflows/screenshots-regenerate.yml
+++ b/.github/workflows/screenshots-regenerate.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: regenerate-screenshots-${{ github.event.issue.number }}
@@ -49,6 +49,7 @@ jobs:
 
       - name: React to comment
         if: steps.pr.outputs.head_repo == github.repository
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Problem

The `screenshots-regenerate.yml` workflow fails with HTTP 403 (`Resource not accessible by integration`) when trying to add a rocket reaction to the `/regenerate-screenshots` comment on PR #199.

The reactions API for comments on **pull requests** requires `pull-requests: write` permission — `issues: write` alone is insufficient because the `issue_comment` event on a PR routes write operations through the pull-requests permission scope.

## Changes

1. **`pull-requests: read` → `pull-requests: write`** — Grants the token permission to create reactions on PR comments
2. **`continue-on-error: true`** on the "React to comment" step — The reaction is cosmetic (acknowledges the command), so it should never block the actual screenshot regeneration

Fixes the failure in https://github.com/maraf/SharedSpaces/actions/runs/30442119989/job/90543649350