### PR TITLE
docs(client): clarify when to use /regenerate-screenshots

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,14 @@
 4. **Regenerate** — If CI fails, comment `/regenerate-screenshots` on the PR to have CI regenerate and commit updated screenshots
 5. **Review** — Check the committed screenshot diff (especially mobile) for regressions, overflow, or broken layout
 
+### When to Use `/regenerate-screenshots`
+
+A screenshot validation failure only means the rendered UI changed — it does not by itself mean the change is correct. Before commenting the slash command:
+
+- Confirm the failure is explained by the UI change you intentionally made (e.g., you changed a component's layout, styles, or copy, and the diff reflects that).
+- If you are not 100% sure the failure only reflects your intended change (e.g., unrelated elements shifted, unexpected diffs, or you didn't touch UI at all), **do not** comment `/regenerate-screenshots`. Investigate the cause first and flag it to the user instead.
+- Only comment the slash command once you can attribute every changed screenshot to an expected, intentional UI change.
+
 **Do not generate or commit screenshots locally.** Only CI-generated screenshots should be committed to the repo. This ensures consistency across environments.
 
 See `.github/skills/playwright-screenshots/SKILL.md` for full details on isolated DB setup, seeding, and viewport specs.


### PR DESCRIPTION
## Why

The screenshot workflow tells agents to comment `/regenerate-screenshots` when CI screenshot validation fails, but a failure only means the rendered UI changed - not that the change is correct. Without guidance, an agent could regenerate screenshots to mask an unintended regression.

## What changed

Added a "When to Use `/regenerate-screenshots`" section to `.github/copilot-instructions.md` that requires the agent to:
- Confirm the screenshot diff is fully explained by an intentional UI change before commenting the slash command.
- Investigate and flag the failure to the user instead, if not 100% sure the diff only reflects the intended change.