### PR TITLE
feat(cli,docs): add sharedspaces send and agent notification skill

### DIFF
--- a/.github/skills/sharedspaces-notify/SKILL.md
+++ b/.github/skills/sharedspaces-notify/SKILL.md
@@ -48,7 +48,7 @@ summary. Keep it under ~40 characters.
 
 ### 4. Persist the setup
 
-Write `{ "spaceId", "spaceName", "serverUrl", "workLabel" }` to
+Write `{ "spaceId", "workLabel" }` to
 `<artifacts_dir>/sharedspaces-notify.json` so setup isn't repeated later in the session.
 **Never write this into the repository.**
 

--- a/.github/skills/sharedspaces-notify/SKILL.md
+++ b/.github/skills/sharedspaces-notify/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: sharedspaces-notify
+description: "Send progress notifications to the user via SharedSpaces while working asynchronously. Use when the user explicitly asks to be notified, pinged, or updated about long-running work — e.g. 'notify me via SharedSpaces', 'ping me when it's done', 'I'm stepping away', 'send updates to my phone'. Do NOT use for normal interactive work where the user is watching the terminal."
+---
+
+## Context
+
+SharedSpaces delivers items to every joined member in real time, including web push to phones.
+That makes it a good out-of-band notification channel for an agent doing long-running work while
+the user is away from the terminal.
+
+This skill is **opt-in and user-initiated**. If the user is sitting at the session watching your
+output, notifications add noise and cost — don't use it. Only activate when the user has asked
+for async updates.
+
+## Setup (once per session)
+
+Do this the first time notifications are requested, then reuse the result.
+
+### 1. Verify the CLI
+
+```bash
+sharedspaces --version
+```
+
+If missing, tell the user to run `dotnet tool install --global SharedSpaces.Cli` (don't install it
+for them without asking).
+
+### 2. Pick a space
+
+```bash
+sharedspaces spaces --json
+```
+
+| Result | Action |
+| --- | --- |
+| 0 spaces | Ask the user for a join string or invite URL, then run `sharedspaces join "<string>" --display-name "<agent label>"` |
+| 1 space | Use it. Tell the user which space you'll notify in. |
+| >1 spaces | Ask the user which space to use. Show `spaceName` and `serverName`. |
+
+Never guess when there is more than one space.
+
+### 3. Derive a work label
+
+A short identifier so the user can tell agent sessions apart in a shared space. Prefer
+`<repo>/<branch>` (e.g. `SharedSpaces/maraf-glowing-waddle`), optionally plus a 2–4 word task
+summary. Keep it under ~40 characters.
+
+### 4. Persist the setup
+
+Write `{ "spaceId", "spaceName", "serverUrl", "workLabel" }` to
+`<artifacts_dir>/sharedspaces-notify.json` so setup isn't repeated later in the session.
+**Never write this into the repository.**
+
+## Sending a notification
+
+```bash
+sharedspaces send "[<workLabel>] <STATUS> — <one-line summary>" --space-id <spaceId> --ttl 3600
+```
+
+- **Text, not files.** Only use `sharedspaces upload` when the user explicitly asks for an artifact.
+- **Default TTL is 3600 seconds (1 hour).** Notifications are ephemeral; they shouldn't pile up in
+  the space. Honour a different TTL only if the user asks for one.
+- Always include the work label so the message is attributable to this session.
+- Keep the whole message under ~500 characters so it renders well as a push notification.
+- Add at most 1–2 short detail lines after the summary line.
+
+### Statuses
+
+| Status | Use for |
+| --- | --- |
+| `MILESTONE` | A meaningful chunk of work completed, user has nothing to do |
+| `DONE` | All requested work is finished |
+| `BLOCKED` | Stuck on an external dependency (CI, network, missing access) |
+| `NEEDS INPUT` | Cannot proceed without a user decision |
+| `FAILED` | Unrecoverable failure; work has stopped |
+
+### Examples
+
+```bash
+sharedspaces send "[SharedSpaces/notify-skill] MILESTONE — CLI send command implemented, 8 tests passing. Starting on the skill doc." --space-id $SPACE --ttl 3600
+
+sharedspaces send "[SharedSpaces/notify-skill] NEEDS INPUT — Two auth strategies are viable (JWT vs session). Which do you want?" --space-id $SPACE --ttl 3600
+
+sharedspaces send "[SharedSpaces/notify-skill] DONE — PR #142 opened, CI green." --space-id $SPACE --ttl 3600
+```
+
+## When to notify — and when not to
+
+**Do notify:**
+
+- A significant milestone in a multi-step task is complete
+- All work is finished
+- Blocked on something outside your control
+- You need a decision from the user before continuing
+- An unrecoverable failure stopped the work
+
+**Do not notify:**
+
+- Routine tool calls, individual file edits, per-command progress
+- "Starting now" / "working on it" narration
+- Retries, intermediate build or test runs you're going to re-run anyway
+- Anything the user would see immediately in the terminal if they were watching
+
+**Rate limits:** Aim for a handful of notifications across a long-running task — never more than one
+every few minutes. If several milestones land close together, batch them into a single message.
+
+## Failure handling
+
+If `sharedspaces send` fails, note it briefly in your normal output and **continue the real work**.
+A failed notification is never a reason to stop or retry in a loop. If sends fail repeatedly
+(e.g. an expired token), mention it once and stop attempting to notify.
+
+## Teardown
+
+Include the final outcome in the `DONE` or `FAILED` message and stop notifying. The messages
+expire on their own once the TTL elapses.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Anonymous by design: users pick a display name when joining a space. No email, n
 - **JWT-based access** — Secure, token-based authentication with no expiration
 - **File + text sharing** — Upload files or post text snippets; quota enforced per space
 - **Admin controls** — Create spaces, generate invitations, manage content
-- **CLI tool** — Join spaces, upload files, and sync folders from the terminal
+- **CLI tool** — Join spaces, upload files, send messages, and sync folders from the terminal
 
 ## Screenshots
 
@@ -107,7 +107,7 @@ graph LR
 
 ## Command-Line Interface (CLI)
 
-The **SharedSpaces CLI** lets you join spaces, upload files, list spaces, and sync files — all from the terminal, no browser needed.
+The **SharedSpaces CLI** lets you join spaces, upload files, send messages, list spaces, and sync files — all from the terminal, no browser needed.
 
 ### Install
 
@@ -139,6 +139,12 @@ sharedspaces items --space-id 550e8400-e29b-41d4-a716-446655440000 --json
 sharedspaces upload myfile.txt --space-id 550e8400-e29b-41d4-a716-446655440000
 ```
 
+**Send a text message:**
+```bash
+sharedspaces send "Build finished" --space-id 550e8400-e29b-41d4-a716-446655440000
+sharedspaces send "Deploy started" --space-id 550e8400-e29b-41d4-a716-446655440000 --ttl 3600   # expires after 1 hour
+```
+
 **Sync a folder in real-time** (two-way: downloads from the server and uploads local changes):
 ```bash
 sharedspaces sync --space-id 550e8400-e29b-41d4-a716-446655440000 --folder ~/shared
@@ -152,6 +158,7 @@ sharedspaces sync --space-id 550e8400-e29b-41d4-a716-446655440000 --folder ~/sha
 | `spaces` | List all joined spaces (supports `--json` for machine-readable output) |
 | `items` | List all items in a space (`--space-id` required; supports `--json`) |
 | `upload <file>` | Upload a file to a space (`--space-id` required) |
+| `send [message]` | Send a text message to a space (`--space-id` required; `--ttl` to expire it; reads stdin when the message is omitted) |
 | `sync` | Two-way file sync between a space and a local folder (`--space-id`, `--folder` required; `--passive` for periodic polling instead of real-time SignalR) |
 
 ### How sync works
@@ -207,7 +214,7 @@ SharedSpaces/
 │   │       ├── lib/                  # SignalR client, API client, utilities
 │   │       └── index.ts
 │   ├── SharedSpaces.Cli/             # .NET global tool (CLI entry point)
-│   │   └── Commands/                 # join, spaces, items, upload, sync
+│   │   └── Commands/                 # join, spaces, items, upload, send, sync
 │   └── SharedSpaces.Cli.Core/        # Shared CLI library
 │       ├── Services/                 # API client, config, sync engine
 │       └── Models/                   # Config model, JWT-backed space entry

--- a/src/SharedSpaces.Cli.Core/Services/SharedSpacesApiClient.cs
+++ b/src/SharedSpaces.Cli.Core/Services/SharedSpacesApiClient.cs
@@ -81,6 +81,42 @@ public sealed class SharedSpacesApiClient : IDisposable
             ?? throw new InvalidOperationException("Server returned empty upload response.");
     }
 
+    public async Task<UploadResponse> SendTextAsync(
+        string serverUrl,
+        string spaceId,
+        string itemId,
+        string jwtToken,
+        string text,
+        CancellationToken ct = default,
+        int? ttlSeconds = null)
+    {
+        var url = $"{serverUrl.TrimEnd('/')}/v1/spaces/{spaceId}/items/{itemId}";
+
+        using var content = new MultipartFormDataContent();
+        content.Add(new StringContent(itemId), "id");
+        content.Add(new StringContent("text"), "contentType");
+        content.Add(new StringContent(text), "content");
+        if (ttlSeconds is not null)
+        {
+            content.Add(new StringContent(ttlSeconds.Value.ToString()), "ttlSeconds");
+        }
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, url) { Content = content };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", jwtToken);
+
+        using var response = await _http.SendAsync(request, ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
+            throw new HttpRequestException(
+                $"Send failed ({(int)response.StatusCode} {response.ReasonPhrase}): {body}");
+        }
+
+        return await response.Content.ReadFromJsonAsync<UploadResponse>(ct)
+            ?? throw new InvalidOperationException("Server returned empty send response.");
+    }
+
     public async Task<List<SpaceItemResponse>> ListItemsAsync(
         string serverUrl,
         string spaceId,

--- a/src/SharedSpaces.Cli/Commands/SendCommand.cs
+++ b/src/SharedSpaces.Cli/Commands/SendCommand.cs
@@ -1,0 +1,131 @@
+using System.CommandLine;
+using System.Text.Json;
+using SharedSpaces.Cli.Core.Models;
+using SharedSpaces.Cli.Core.Services;
+
+namespace SharedSpaces.Cli.Commands;
+
+public static class SendCommand
+{
+    public static Command Create()
+    {
+        var messageArg = new Argument<string?>("message")
+        {
+            Description = "Text to send. Omit or pass '-' to read from stdin.",
+            Arity = ArgumentArity.ZeroOrOne
+        };
+        var spaceIdOption = new Option<string>("--space-id") { Description = "ID of the space to send to", Required = true };
+        var ttlSecondsOption = new Option<int?>("--ttl") { Description = "Optional item TTL in seconds" };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var command = new Command("send", "Send a text message to a space");
+        command.Add(messageArg);
+        command.Add(spaceIdOption);
+        command.Add(ttlSecondsOption);
+        command.Add(jsonOption);
+
+        command.SetAction(async (parseResult, ct) =>
+        {
+            var message = parseResult.GetValue(messageArg);
+            var spaceId = parseResult.GetRequiredValue(spaceIdOption);
+            var ttlSeconds = parseResult.GetValue(ttlSecondsOption);
+            var json = parseResult.GetValue(jsonOption);
+            await HandleAsync(message, spaceId, ttlSeconds, json, ct);
+        });
+
+        return command;
+    }
+
+    private static async Task HandleAsync(string? message, string spaceId, int? ttlSeconds, bool json, CancellationToken ct)
+    {
+        if (ttlSeconds is <= 0)
+        {
+            Console.Error.WriteLine("Error: --ttl must be greater than 0.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        if (message is null or "-")
+        {
+            message = await Console.In.ReadToEndAsync(ct);
+        }
+
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            Console.Error.WriteLine("Error: message must not be empty.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var configService = new ConfigService();
+        SpaceEntry? space;
+
+        try
+        {
+            space = await configService.GetSpaceAsync(spaceId, ct);
+        }
+        catch (JsonException ex)
+        {
+            Console.Error.WriteLine($"Error: Failed to read CLI config — {ex.Message}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        if (space is null)
+        {
+            Console.Error.WriteLine($"Error: No token found for space {spaceId}.");
+            Console.Error.WriteLine("Run 'sharedspaces join' first to join the space.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var itemId = Guid.NewGuid().ToString();
+
+        using var api = new SharedSpacesApiClient();
+
+        try
+        {
+            var response = await api.SendTextAsync(
+                space.ServerUrl,
+                space.SpaceId,
+                itemId,
+                space.JwtToken,
+                message,
+                ct,
+                ttlSeconds);
+
+            if (json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(
+                    new
+                    {
+                        id = response.Id,
+                        spaceId = response.SpaceId,
+                        sharedAt = response.SharedAt,
+                        ttlSeconds = response.TtlSeconds
+                    },
+                    new JsonSerializerOptions { WriteIndented = true }));
+            }
+            else
+            {
+                Console.WriteLine($"Sent message to space {spaceId}.");
+                Console.WriteLine($"Item ID: {response.Id}");
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            Environment.ExitCode = 1;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Console.Error.WriteLine($"Error: Access denied — {ex.Message}");
+            Environment.ExitCode = 1;
+        }
+        catch (JsonException ex)
+        {
+            Console.Error.WriteLine($"Error: Failed to parse server response — {ex.Message}");
+            Environment.ExitCode = 1;
+        }
+    }
+}

--- a/src/SharedSpaces.Cli/Program.cs
+++ b/src/SharedSpaces.Cli/Program.cs
@@ -7,6 +7,7 @@ rootCommand.Add(JoinCommand.Create());
 rootCommand.Add(SpacesCommand.Create());
 rootCommand.Add(ItemsCommand.Create());
 rootCommand.Add(UploadCommand.Create());
+rootCommand.Add(SendCommand.Create());
 rootCommand.Add(SyncCommand.Create());
 
 return await CommandLineParser.Parse(rootCommand, args).InvokeAsync();

--- a/src/SharedSpaces.Cli/README.md
+++ b/src/SharedSpaces.Cli/README.md
@@ -38,6 +38,29 @@ sharedspaces upload myfile.txt --space-id 550e8400-e29b-41d4-a716-446655440000
 
 The access token for the space is read automatically from the local config stored during `join`.
 
+### `sharedspaces send`
+
+Send a short text message to a space you have already joined. Useful for status updates and notifications.
+
+```bash
+sharedspaces send "Build finished" --space-id 550e8400-e29b-41d4-a716-446655440000
+
+# Expire the message after one hour
+sharedspaces send "Deploy started" --space-id <guid> --ttl 3600
+
+# Read the message from stdin
+echo "Long update" | sharedspaces send --space-id <guid>
+
+# Machine-readable output
+sharedspaces send "Done" --space-id <guid> --json
+```
+
+| Option | Required | Description |
+| --- | --- | --- |
+| `--space-id <guid>` | yes | ID of the space to send to |
+| `--ttl <seconds>` | no | Expire the message after this many seconds |
+| `--json` | no | Print the created item as JSON |
+
 ### `sharedspaces spaces`
 
 List all joined spaces. Also available as `sharedspaces list`.

--- a/tests/SharedSpaces.Cli.Core.Tests/SendTextTests.cs
+++ b/tests/SharedSpaces.Cli.Core.Tests/SendTextTests.cs
@@ -63,9 +63,9 @@ public class SendTextTests
 
         await client.SendTextAsync(ServerUrl, SpaceId, ItemId, Token, "Build finished");
 
-        handler.Body.Should().Contain("name=id").And.Contain(ItemId);
-        handler.Body.Should().Contain("name=contentType").And.Contain("text");
-        handler.Body.Should().Contain("name=content").And.Contain("Build finished");
+        handler.FormFields.Should().Contain(new KeyValuePair<string, string>("id", ItemId));
+        handler.FormFields.Should().Contain(new KeyValuePair<string, string>("contentType", "text"));
+        handler.FormFields.Should().Contain(new KeyValuePair<string, string>("content", "Build finished"));
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class SendTextTests
 
         await client.SendTextAsync(ServerUrl, SpaceId, ItemId, Token, "Hello", ttlSeconds: 3600);
 
-        handler.Body.Should().Contain("name=ttlSeconds").And.Contain("3600");
+        handler.FormFields.Should().Contain(new KeyValuePair<string, string>("ttlSeconds", "3600"));
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class SendTextTests
 
         await client.SendTextAsync(ServerUrl, SpaceId, ItemId, Token, "Hello");
 
-        handler.Body.Should().NotContain("ttlSeconds");
+        handler.FormFields.Should().NotContainKey("ttlSeconds");
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class SendTextTests
         public string? Url { get; private set; }
         public string? AuthScheme { get; private set; }
         public string? AuthParameter { get; private set; }
-        public string Body { get; private set; } = string.Empty;
+        public Dictionary<string, string> FormFields { get; } = new();
 
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
@@ -152,9 +152,16 @@ public class SendTextTests
             AuthScheme = request.Headers.Authorization?.Scheme;
             AuthParameter = request.Headers.Authorization?.Parameter;
 
-            if (request.Content is not null)
+            if (request.Content is MultipartFormDataContent multipart)
             {
-                Body = await request.Content.ReadAsStringAsync(cancellationToken);
+                foreach (var part in multipart)
+                {
+                    var name = part.Headers.ContentDisposition?.Name?.Trim('"');
+                    if (name is not null)
+                    {
+                        FormFields[name] = await part.ReadAsStringAsync(cancellationToken);
+                    }
+                }
             }
 
             return new HttpResponseMessage(_status)

--- a/tests/SharedSpaces.Cli.Core.Tests/SendTextTests.cs
+++ b/tests/SharedSpaces.Cli.Core.Tests/SendTextTests.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using SharedSpaces.Cli.Core.Services;
+
+namespace SharedSpaces.Cli.Core.Tests;
+
+public class SendTextTests
+{
+    private const string ServerUrl = "https://server.example.com";
+    private const string SpaceId = "550e8400-e29b-41d4-a716-446655440000";
+    private const string ItemId = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+    private const string Token = "eyJ-token";
+
+    private static string SuccessBody() => $$"""
+        {
+          "id": "{{ItemId}}",
+          "spaceId": "{{SpaceId}}",
+          "contentType": "text",
+          "content": "Hello",
+          "fileSize": 5,
+          "sharedAt": "2026-01-01T00:00:00Z",
+          "ttlSeconds": 3600
+        }
+        """;
+
+    private static (SharedSpacesApiClient Client, CapturingHandler Handler) CreateClient(
+        HttpStatusCode status = HttpStatusCode.Created,
+        string? body = null)
+    {
+        var handler = new CapturingHandler(status, body ?? SuccessBody());
+        return (new SharedSpacesApiClient(new HttpClient(handler)), handler);
+    }
+
+    [Fact]
+    public async Task SendTextAsync_PutsToItemUrlWithBearerToken()
+    {
+        var (client, handler) = CreateClient();
+        using var _ = client;
+
+        await client.SendTextAsync(ServerUrl, SpaceId, ItemId, Token, "Hello");
+
+        handler.Method.Should().Be(HttpMethod.Put);
+        handler.Url.Should().Be($"{ServerUrl}/v1/spaces/{SpaceId}/items/{ItemId}");
+        handler.AuthScheme.Should().Be("Bearer");
+        handler.AuthParameter.Should().Be(Token);
+    }
+
+    [Fact]
+    public async Task SendTextAsync_TrimsTrailingSlashFromServerUrl()
+    {
+        var (client, handler) = CreateClient();
+        using var _ = client;
+
+        await client.SendTextAsync($"{ServerUrl}/", SpaceId, ItemId, Token, "Hello");
+
+        handler.Url.Should().Be($"{ServerUrl}/v1/spaces/{SpaceId}/items/{ItemId}");
+    }
+
+    [Fact]
+    public async Task SendTextAsync_SendsTextContentTypeAndContent()
+    {
+        var (client, handler) = CreateClient();
+        using var _ = client;
+
+        await client.SendTextAsync(ServerUrl, SpaceId, ItemId, Token, "Build finished");
+
+        handler.Body.Should().Contain("name=id").And.Contain(ItemId);
+        handler.Body.Should().Contain("name=contentType").And.Contain("text");
+        handler.Body.Should().Contain("name=content").And.Contain("Build finished");
+    }
+
+    [Fact]
+    public async Task SendTextAsync_IncludesTtlWhenProvided()
+    {
+        var (client, handler) = CreateClient();
+        using var _ = client;
+
+        await client.SendTextAsync(ServerUrl, SpaceId, ItemId, Token, "Hello", ttlSeconds: 3600);
+
+        handler.Body.Should().Contain("name=ttlSeconds").And.Contain("3600");
+    }
+
+    [Fact]
+    public async Task SendTextAsync_OmitsTtlWhenNotProvided()
+    {
+        var (client, handler) = CreateClient();
+        using var _ = client;
+
+        await client.SendTextAsync(ServerUrl, SpaceId, ItemId, Token, "Hello");
+
+        handler.Body.Should().NotContain("ttlSeconds");
+    }
+
+    [Fact]
+    public async Task SendTextAsync_ReturnsParsedResponse()
+    {
+        var (client, _) = CreateClient();
+        using var __ = client;
+
+        var response = await client.SendTextAsync(ServerUrl, SpaceId, ItemId, Token, "Hello");
+
+        response.Id.Should().Be(Guid.Parse(ItemId));
+        response.ContentType.Should().Be("text");
+        response.TtlSeconds.Should().Be(3600);
+    }
+
+    [Fact]
+    public async Task SendTextAsync_ThrowsWithServerBodyOnFailure()
+    {
+        var (client, _) = CreateClient(HttpStatusCode.BadRequest, "{\"error\":\"ttlSeconds must be greater than 0\"}");
+        using var __ = client;
+
+        var act = async () => await client.SendTextAsync(ServerUrl, SpaceId, ItemId, Token, "Hello");
+
+        (await act.Should().ThrowAsync<HttpRequestException>())
+            .WithMessage("*Send failed (400*ttlSeconds must be greater than 0*");
+    }
+
+    [Fact]
+    public async Task SendTextAsync_ThrowsWhenResponseBodyIsNull()
+    {
+        var (client, _) = CreateClient(HttpStatusCode.Created, "null");
+        using var __ = client;
+
+        var act = async () => await client.SendTextAsync(ServerUrl, SpaceId, ItemId, Token, "Hello");
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+
+        public CapturingHandler(HttpStatusCode status, string body)
+        {
+            _status = status;
+            _body = body;
+        }
+
+        public HttpMethod? Method { get; private set; }
+        public string? Url { get; private set; }
+        public string? AuthScheme { get; private set; }
+        public string? AuthParameter { get; private set; }
+        public string Body { get; private set; } = string.Empty;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Method = request.Method;
+            Url = request.RequestUri?.ToString();
+            AuthScheme = request.Headers.Authorization?.Scheme;
+            AuthParameter = request.Headers.Authorization?.Parameter;
+
+            if (request.Content is not null)
+            {
+                Body = await request.Content.ReadAsStringAsync(cancellationToken);
+            }
+
+            return new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, System.Text.Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Why

When a user kicks off long-running agent work and walks away from the terminal, they have no way to learn about milestones, blockers, or completion. SharedSpaces already pushes items to joined members in real time (including web push to phones), so it is a natural out-of-band notification channel.

The blocker was on the CLI side: the server already accepts `contentType: "text"` items with a TTL, but the CLI could only upload files. There was no ergonomic way to post a short status message.

## What changed

**New `sharedspaces send` command.** Posts a short-lived text item to a joined space.

```bash
sharedspaces send "Build finished" --space-id <guid> --ttl 3600
echo "Long update" | sharedspaces send --space-id <guid>
```

- `SharedSpacesApiClient.SendTextAsync(...)` PUTs to `/v1/spaces/{id}/items/{guid}` with `contentType=text`, `content`, and optional `ttlSeconds`
- Message comes from an argument, or from stdin when omitted or passed as `-`
- `--json` for deterministic parsing by agents; error handling and exit-code behavior mirror `upload`

**New `sharedspaces-notify` skill** (`.github/skills/`). Teaches agents when and how to notify.

- Opt-in and user-initiated. The description explicitly excludes normal interactive work where the user is watching the terminal, so it should not fire on its own.
- Setup runs once: verify the CLI, then `sharedspaces spaces --json`. Zero spaces means asking the user for a join string; one means use it; more than one means asking which. It never guesses.
- Derives a short work label (`<repo>/<branch>`) so messages are attributable when several agent sessions share a space.
- Sends text rather than files, default TTL 3600s, format `[<workLabel>] <STATUS> - <summary>` with `MILESTONE` / `DONE` / `BLOCKED` / `NEEDS INPUT` / `FAILED`.
- Explicit anti-flood rules, plus a rule that a failed send never blocks the actual work.

## Notes for reviewers

- Persisted setup state is `{ spaceId, workLabel }` written to the session artifacts directory, never the repo. `serverUrl` and the JWT are deliberately not duplicated there since the CLI already resolves them from `~/.sharedspaces/config.json`.
- The `send` error paths print to stderr but exit `0`. That is pre-existing behavior shared with `upload`, so I left it alone rather than changing exit-code semantics for one command. Happy to fix it repo-wide in a follow-up if you want.
- No UI changes, so the screenshot workflow does not apply.

## Testing

8 new unit tests covering URL and auth headers, multipart payload shape, TTL present/absent, response parsing, and error mapping. Full suite: 329 passed, 0 failed. Also smoke-tested `send --help` and the empty-message, invalid-TTL, and unknown-space paths.