### PR TITLE
docs(client,server): document Aspire development flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,26 @@ A screenshot validation failure only means the rendered UI changed — it does n
 
 See `.github/skills/playwright-screenshots/SKILL.md` for full details on isolated DB setup, seeding, and viewport specs.
 
+## Agent Test State Setup
+
+When an AI agent needs realistic app state for development tests or browser verification, create that state through the public/admin HTTP APIs instead of editing SQLite directly. For normal development testing, use the default Aspire AppHost and development database:
+
+```bash
+cd src
+dotnet run AppHost.cs
+```
+
+Default local URLs are the Vite client at `http://localhost:5173` and the server at `http://localhost:5165`. Read the admin secret from `Admin:Secret` in `src/SharedSpaces.Server/appsettings.Development.json`. Use an isolated screenshot database only when capturing screenshots or running visual-regression scenarios that must be deterministic; see `.github/skills/playwright-screenshots/SKILL.md` for that workflow.
+
+Core state setup flows:
+
+- **Create a space:** use the admin API (`POST /v1/spaces`) with `X-Admin-Secret`.
+- **Join a user to a space:** create an invitation for that space (`POST /v1/spaces/{spaceId}/invitations`), extract the one-time PIN from the returned invitation string, then exchange it through `POST /v1/tokens` with a display name. Repeat this invitation/token flow for each member you need.
+- **Open the app as a joined user:** prefer the real join flow with `/?join=<invitationString>` and submit the display-name form. Only seed `localStorage["sharedspaces:tokens"]` and dispatch `view-change` directly for narrowly scoped tests where bypassing the join UI is intentional. The app uses event-based view switching; do not navigate to fake `/space` or `/admin` routes.
+- **Upload an item:** call `PUT /v1/spaces/{spaceId}/items/{itemId}` with the member JWT and `multipart/form-data`. Text items use fields `id`, `contentType=text`, and `content`; file items use fields `id`, `contentType=file`, and `file`. Add `ttlSeconds` when testing expiration behavior.
+- **Create a public shared link:** first upload an item, then call `POST /v1/spaces/{spaceId}/items/{itemId}/share/` with the member JWT. Public reads use `GET /v1/shared/{token}` and public file downloads use `GET /v1/shared/{token}/download`. Client share URLs are built by `src/SharedSpaces.Client/src/lib/share-link.ts`.
+- **Create other useful states:** delete items with `DELETE /v1/spaces/{spaceId}/items/{itemId}`, download member-visible files with `GET /v1/spaces/{spaceId}/items/{itemId}/download`, copy/move items with `POST /v1/spaces/{spaceId}/items/{itemId}/transfer`, and use the journal endpoints when testing sync checkpoints or deletion journal entries.
+
 ### Mobile Layout Checks
 
 After recapturing, inspect mobile screenshots (`390 × 844`) and call out:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,23 @@ graph LR
    cd SharedSpaces
    ```
 
-2. **Run the server:**
+2. **Run the app with Aspire AppHost (recommended):**
+   ```bash
+   cd src
+   dotnet run AppHost.cs
+   ```
+   Aspire starts both the ASP.NET Core server and the Vite client, wires the client URL into the server CORS configuration, and opens the Aspire Dashboard for logs and resource status. The client will be available at `http://localhost:5173`; check the Aspire Dashboard or terminal output for the server URL.
+
+3. **Connect the client to your server:**
+   - Open the client in your browser at `http://localhost:5173`.
+   - Use the client UI to add/connect to your server by entering its URL from Aspire.
+   - No environment variables are required for API routing; the server URL is chosen at runtime in the client.
+
+#### Direct startup fallback
+
+If you do not want to use Aspire, you can still run the server and client manually.
+
+1. **Run the server:**
    ```bash
    cd src/SharedSpaces.Server
    dotnet restore
@@ -92,7 +108,7 @@ graph LR
    ```
    The API will be available at `https://localhost:7218` (or `http://localhost:5165`). Check the terminal output for the exact URL.
 
-3. **Run the client (in a separate terminal):**
+2. **Run the client (in a separate terminal):**
    ```bash
    cd src/SharedSpaces.Client
    npm install
@@ -100,7 +116,7 @@ graph LR
    ```
    The client will be available at `http://localhost:5173`.
 
-4. **Connect the client to your server:**
+3. **Connect the client to your server:**
    - Open the client in your browser at `http://localhost:5173`.
    - Use the client UI to add/connect to your server by entering its URL (e.g., `https://localhost:7218`).
    - No environment variables are required for API routing; the server URL is chosen at runtime in the client.
@@ -230,4 +246,3 @@ The server and client are **fully decoupled**. The server is a pure API with no 
 - **Multi-server by default** — JWT claims include `server_url` so the client knows where to send requests
 
 For detailed architecture, domain model, and API behavior, explore the codebase — the code is the spec, and inline comments call out key design decisions.
-


### PR DESCRIPTION
The README still described direct server and client startup as the main development path, even though the repository is normally run through the Aspire AppHost. This updates the getting-started flow so AppHost is the recommended way to start the full stack, while keeping direct startup as a fallback.

It also adds concise agent-facing guidance for creating realistic development test states through the public/admin APIs: creating spaces, joining users, uploading items, creating shared links, and setting up related states without editing SQLite directly.